### PR TITLE
Add VideoUpscaler: model-agnostic video frame upscale pipeline

### DIFF
--- a/apps/CoreAIStudio/Sources/UpscaleEngine.swift
+++ b/apps/CoreAIStudio/Sources/UpscaleEngine.swift
@@ -1,0 +1,246 @@
+// UpscaleEngine — downloads/loads the AdcSR x4 super-resolution Core AI bundle and runs it
+// natively (no coreai-kit — see project.yml). Host pipeline (tiling, feather-blend, global
+// color-match) is a direct Swift port of apps/CoreAIStudio/reference/adcsr_host_reference.py,
+// which is itself gated (self-consistency: coverage, finiteness, color-match correctness) and
+// run against the real bundle before this file was written — see that script's docstring for
+// why the exact tiling parameters here are an authored contract, not a reverse-engineered
+// clone of the closed-source CoreAIKitVision `SuperResolver`.
+//
+// Graph contract (conversion/export_adcsr.py, ✓ VERIFIED by reading the export code): lr
+// [1,3,128,128] in [-1,1] -> sr [1,3,512,512], no in-graph normalization — the host does
+// rgb*2-1 in, clamp((sr+1)/2) out. Compute unit: GPU (a large diffusion-derived graph — the
+// Mac-native "large model / max throughput" tier, per knowledge/compute-units-and-authoring.md;
+// this is also the OTHER half of the app's "use the whole chip" story alongside RIFE's ANE
+// split — see conversion/rife_compute_router.py).
+
+import CoreAI
+import CoreGraphics
+import Foundation
+
+@MainActor
+final class UpscaleEngine: ObservableObject {
+    struct ModelOption: Identifiable, Hashable {
+        var id: String { repoId }
+        let repoId: String
+        let bundleDirName: String
+        let title: String
+        let aimodelName: String
+    }
+
+    static let catalog: [ModelOption] = [
+        ModelOption(
+            repoId: "mlboydaisuke/AdcSR-CoreAI",
+            bundleDirName: "adcsr-CoreAI",
+            title: "AdcSR ×4",
+            aimodelName: "adcsr_x4_float32.aimodel")
+    ]
+
+    enum Status: Equatable {
+        case idle, downloading, loading, ready, upscaling
+        case error(String)
+
+        var label: String {
+            switch self {
+            case .idle: return "No model loaded"
+            case .downloading: return "Downloading AdcSR (~1.7 GB)…"
+            case .loading: return "Loading model…"
+            case .ready: return "Ready"
+            case .upscaling: return "Upscaling ×4 on GPU…"
+            case .error(let m): return "Error: \(m)"
+            }
+        }
+
+        var isBusy: Bool {
+            switch self {
+            case .downloading, .loading, .upscaling: return true
+            default: return false
+            }
+        }
+    }
+
+    @Published private(set) var status: Status = .idle
+    @Published private(set) var sourceImage: CGImage?
+    @Published private(set) var resultImage: CGImage?
+    @Published private(set) var upscaleSeconds: Double?
+    @Published private(set) var modelTitle = ""
+
+    let downloader = ModelDownloader()
+
+    private var fn: InferenceFunction?
+    private var work: Task<Void, Never>?
+
+    // Tiling contract — see this file's header + adcsr_host_reference.py.
+    // nonisolated: read from the nonisolated static run/tiling functions below (a @MainActor
+    // class's static members are actor-isolated by default; these are plain constants, safe
+    // to free from that).
+    nonisolated private static let tile = 128
+    nonisolated private static let scale = 4
+    nonisolated private static let srTile = tile * scale
+    nonisolated private static let maxInputSide = 512
+    nonisolated private static let overlap = 16
+    nonisolated private static let stride = tile - overlap
+
+    var canUpscale: Bool {
+        if case .ready = status { return true }
+        return false
+    }
+
+    func setImage(_ cg: CGImage) {
+        sourceImage = cg
+        resultImage = nil
+        upscaleSeconds = nil
+        if case .error = status { status = fn != nil ? .ready : .idle }
+    }
+
+    // MARK: - Loading
+
+    func loadFromHub(_ option: ModelOption = UpscaleEngine.catalog[0]) {
+        work?.cancel()
+        modelTitle = option.title
+        status = .downloading
+        work = Task {
+            do {
+                let dest = try Self.bundleDestination(for: option)
+                await downloader.fetch(
+                    repo: "https://huggingface.co/\(option.repoId)",
+                    items: [.init(remote: option.aimodelName, local: option.aimodelName)],
+                    into: dest)
+                try Task.checkCancellation()
+                if case .failed(let msg) = downloader.phase { throw Self.err(msg) }
+                try await loadBundle(at: dest.appendingPathComponent(option.aimodelName))
+            } catch is CancellationError {
+            } catch {
+                status = .error("\(error)")
+            }
+        }
+    }
+
+    func loadLocal(_ url: URL) {
+        work?.cancel()
+        modelTitle = url.lastPathComponent
+        work = Task {
+            do { try await loadBundle(at: url) }
+            catch { status = .error("\(error)") }
+        }
+    }
+
+    private func loadBundle(at url: URL) async throws {
+        status = .loading
+        let accessed = url.startAccessingSecurityScopedResource()
+        defer { if accessed { url.stopAccessingSecurityScopedResource() } }
+        let opts = ComputeRouter.specializationOptions(for: .gpu)
+        let model = try await AIModel(contentsOf: url, options: opts)
+        guard let f = try model.loadFunction(named: "main") else {
+            throw Self.err("bundle has no 'main' function")
+        }
+        try Task.checkCancellation()
+        fn = f
+        status = .ready
+    }
+
+    // MARK: - Upscale
+
+    func upscale() {
+        guard let fn, let source = sourceImage, !status.isBusy else { return }
+        status = .upscaling
+        resultImage = nil
+        work = Task {
+            do {
+                let t0 = Date()
+                let out = try await Self.runUpscale(fn: fn, image: source)
+                try Task.checkCancellation()
+                resultImage = out
+                upscaleSeconds = Date().timeIntervalSince(t0)
+                status = .ready
+            } catch is CancellationError {
+            } catch {
+                status = .error("\(error)")
+            }
+        }
+    }
+
+    func cancel() {
+        work?.cancel()
+        if status.isBusy { status = fn != nil ? .ready : .idle }
+    }
+
+    // MARK: - Core algorithm (nonisolated: runs off the main actor; InferenceFunction/AIModel
+    // are Sendable structs, so no @unchecked Sendable box is needed here, unlike engines built
+    // on higher-level non-Sendable runtime types).
+
+    nonisolated private static func runUpscale(fn: InferenceFunction, image: CGImage) async throws -> CGImage {
+        let capped = try capToMaxSide(image, maxSide: maxInputSide)
+        let source = try RGBBuffer(cgImage: capped)
+        let xs = tileOrigins(size: source.width, tile: tile, stride: stride)
+        let ys = tileOrigins(size: source.height, tile: tile, stride: stride)
+
+        var canvas = RGBBuffer(width: source.width * scale, height: source.height * scale)
+        var weightSum = [Float](repeating: 0, count: canvas.width * canvas.height)
+
+        for (iy, oy) in ys.enumerated() {
+            for (ix, ox) in xs.enumerated() {
+                let lrTile = source.cropped(x: ox, y: oy, width: tile, height: tile)
+                let srTileBuf = try await runTile(fn: fn, lrTile: lrTile)
+                let feather = featherWeight(
+                    tilePx: srTile, overlapPx: overlap, scale: scale,
+                    hasLeft: ix > 0, hasRight: ix < xs.count - 1,
+                    hasTop: iy > 0, hasBottom: iy < ys.count - 1)
+                canvas.accumulate(srTileBuf, weight: feather, at: ox * scale, y: oy * scale, into: &weightSum)
+            }
+        }
+        canvas.normalize(by: weightSum)
+        canvas.colorMatch(to: source)  // GLOBAL, once, after stitching — see file header
+        return try canvas.toCGImage()
+    }
+
+    nonisolated private static func runTile(fn: InferenceFunction, lrTile: RGBBuffer) async throws -> RGBBuffer {
+        let x = lrTile.toNDArray(scale: 2.0, offset: -1.0)  // [0,1] -> [-1,1]
+        var outputs = try await fn.run(inputs: ["lr": x])
+        guard let value = outputs.remove("sr"), let sr = value.ndArray else {
+            throw NSError(domain: "UpscaleEngine", code: 1, userInfo: [NSLocalizedDescriptionKey: "no 'sr' output"])
+        }
+        return try RGBBuffer(ndArray: sr, scale: 0.5, offset: 0.5)  // [-1,1] -> [0,1] (clamped in colorMatch/toCGImage)
+    }
+
+    nonisolated private static func capToMaxSide(_ image: CGImage, maxSide: Int) throws -> CGImage {
+        let w = image.width, h = image.height
+        let longSide = max(w, h)
+        var scaleFactor: Double = 1.0
+        if longSide > maxSide {
+            scaleFactor = Double(maxSide) / Double(longSide)
+        } else if min(w, h) < tile {
+            scaleFactor = Double(tile) / Double(min(w, h))
+        }
+        if scaleFactor == 1.0 { return image }
+        let newW = max(tile, Int((Double(w) * scaleFactor).rounded()))
+        let newH = max(tile, Int((Double(h) * scaleFactor).rounded()))
+        return try resizeImage(image, toWidth: newW, height: newH)
+    }
+
+    // MARK: - Storage / errors
+
+    private static func bundleDestination(for option: ModelOption) throws -> URL {
+        let docs = try FileManager.default.url(
+            for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+        let dir = docs.appendingPathComponent(option.bundleDirName, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private static func err(_ msg: String) -> NSError {
+        NSError(domain: "UpscaleEngine", code: 1, userInfo: [NSLocalizedDescriptionKey: msg])
+    }
+}
+
+// MARK: - FrameUpscaler conformance (VideoUpscaler.swift) — exposes the already-loaded `fn`
+// through the model-agnostic per-frame protocol, so VideoUpscaler never depends on UpscaleEngine
+// concretely. Declared in this file (not an extension elsewhere) because it needs access to the
+// private `fn` property.
+
+extension UpscaleEngine: FrameUpscaler {
+    @MainActor
+    func upscale(_ image: CGImage) async throws -> CGImage {
+        guard let fn else { throw Self.err("no model loaded") }
+        return try await Self.runUpscale(fn: fn, image: image)
+    }
+}

--- a/apps/CoreAIStudio/Sources/VideoUpscaler.swift
+++ b/apps/CoreAIStudio/Sources/VideoUpscaler.swift
@@ -1,0 +1,273 @@
+// VideoUpscaler — AVFoundation frame-by-frame video super-resolution pipeline. Mirrors
+// VideoInterpolator's AVAssetReader/AVAssetWriter/audio-passthrough/progress/cancellation
+// structure (see that file), but is deliberately model-agnostic: it depends on the
+// `FrameUpscaler` protocol below, not on UpscaleEngine (AdcSR) concretely, so a future
+// PiperSR-based conformer can be swapped in at the call site without touching this file again.
+//
+// Divergence from VideoInterpolator: RIFE needs frame PAIRS (buffer-the-whole-clip is the
+// simplest correct thing there), but upscaling is a per-frame, embarrassingly-independent
+// operation — each decoded frame is upscaled and written immediately, one at a time, with no
+// need to hold the whole clip in memory first. The output frame size also isn't known upfront
+// (a FrameUpscaler's scale factor is opaque to this file by design), so the writer/adaptor are
+// configured lazily, once the first frame's upscaled size is known.
+
+import AVFoundation
+import CoreGraphics
+import CoreImage
+import Foundation
+
+/// Model-agnostic per-frame upscaler. UpscaleEngine (AdcSR) conforms to this in
+/// UpscaleEngine.swift; a future PiperSR engine can conform the same way.
+protocol FrameUpscaler {
+    func upscale(_ image: CGImage) async throws -> CGImage
+}
+
+@MainActor
+final class VideoUpscaler: ObservableObject {
+    struct SourceInfo: Equatable {
+        let width: Int
+        let height: Int
+        let fps: Double
+        let duration: Double
+        let frameCount: Int
+    }
+
+    enum Status: Equatable {
+        case idle
+        case analyzing
+        case working(progress: Double)
+        case done(URL)
+        case error(String)
+
+        var isBusy: Bool {
+            switch self {
+            case .analyzing, .working: return true
+            default: return false
+            }
+        }
+    }
+
+    @Published private(set) var status: Status = .idle
+    @Published private(set) var sourceInfo: SourceInfo?
+
+    private let upscaler: FrameUpscaler
+    private var work: Task<Void, Never>?
+
+    init(upscaler: FrameUpscaler) {
+        self.upscaler = upscaler
+    }
+
+    func loadSource(_ url: URL) {
+        work?.cancel()
+        status = .analyzing
+        work = Task {
+            do {
+                sourceInfo = try await Self.analyze(url: url)
+                status = .idle
+            } catch is CancellationError {
+            } catch {
+                status = .error("\(error)")
+            }
+        }
+    }
+
+    func run(sourceURL: URL, outputURL: URL) {
+        work?.cancel()
+        status = .working(progress: 0)
+        work = Task {
+            do {
+                try await self.process(sourceURL: sourceURL, outputURL: outputURL) { p in
+                    self.status = .working(progress: p)
+                }
+                try Task.checkCancellation()
+                status = .done(outputURL)
+            } catch is CancellationError {
+            } catch {
+                status = .error("\(error)")
+            }
+        }
+    }
+
+    func cancel() {
+        work?.cancel()
+        if status.isBusy { status = .idle }
+    }
+
+    // MARK: - Analysis
+
+    private static func analyze(url: URL) async throws -> SourceInfo {
+        let asset = AVURLAsset(url: url)
+        guard let track = try await asset.loadTracks(withMediaType: .video).first else {
+            throw err("no video track")
+        }
+        let size = try await track.load(.naturalSize)
+        let fps = try await track.load(.nominalFrameRate)
+        let duration = try await asset.load(.duration)
+        let seconds = CMTimeGetSeconds(duration)
+        let frameCount = Int((seconds * Double(fps)).rounded())
+        return SourceInfo(
+            width: Int(size.width), height: Int(size.height),
+            fps: Double(fps), duration: seconds, frameCount: frameCount)
+    }
+
+    // MARK: - Pipeline
+
+    private func process(sourceURL: URL, outputURL: URL, progress: @escaping (Double) -> Void) async throws {
+        let asset = AVURLAsset(url: sourceURL)
+        guard let videoTrack = try await asset.loadTracks(withMediaType: .video).first else {
+            throw Self.err("no video track")
+        }
+        let nominalFPS = Double(try await videoTrack.load(.nominalFrameRate))
+        let duration = try await asset.load(.duration)
+        let seconds = CMTimeGetSeconds(duration)
+        let estimatedFrameCount = max(1, Int((seconds * nominalFPS).rounded()))
+
+        if FileManager.default.fileExists(atPath: outputURL.path) {
+            try FileManager.default.removeItem(at: outputURL)
+        }
+
+        let reader = try AVAssetReader(asset: asset)
+        let videoOutputSettings: [String: Any] = [kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA]
+        let videoReaderOutput = AVAssetReaderTrackOutput(track: videoTrack, outputSettings: videoOutputSettings)
+        videoReaderOutput.alwaysCopiesSampleData = false
+        reader.add(videoReaderOutput)
+
+        let audioTrack = try await asset.loadTracks(withMediaType: .audio).first
+        var audioReaderOutput: AVAssetReaderTrackOutput?
+        var audioFormatHint: CMFormatDescription?
+        if let audioTrack {
+            let out = AVAssetReaderTrackOutput(track: audioTrack, outputSettings: nil)
+            reader.add(out)
+            audioReaderOutput = out
+            // A nil-outputSettings (passthrough) AVAssetWriterInput needs a source format hint
+            // on this SDK, or writer.add(_:) throws NSInvalidArgumentException at runtime
+            // (✓ VERIFIED: reproduced via the e2e harness before this fix was added).
+            audioFormatHint = try await audioTrack.load(.formatDescriptions).first
+        }
+
+        let writer = try AVAssetWriter(outputURL: outputURL, fileType: .mp4)
+
+        guard reader.startReading() else { throw Self.err("reader failed: \(reader.error?.localizedDescription ?? "unknown")") }
+
+        // Output frame size is unknown until the first upscale (the FrameUpscaler's scale
+        // factor is opaque here by design) — the writer/adaptor/writer.startWriting() are all
+        // set up lazily, once we've upscaled frame 0.
+        var writerInput: AVAssetWriterInput?
+        var adaptor: AVAssetWriterInputPixelBufferAdaptor?
+        var audioWriterInput: AVAssetWriterInput?
+        var writerStarted = false
+        var outW = 0, outH = 0
+
+        let frameDuration = CMTime(value: 1, timescale: CMTimeScale(nominalFPS.rounded()))
+        var presentationTime = CMTime.zero
+        var written = 0
+
+        let ciContext = CIContext()
+
+        func startWriterIfNeeded(sampleWidth: Int, sampleHeight: Int) throws {
+            guard !writerStarted else { return }
+            outW = sampleWidth
+            outH = sampleHeight
+
+            let videoSettings: [String: Any] = [
+                AVVideoCodecKey: AVVideoCodecType.h264,
+                AVVideoWidthKey: outW,
+                AVVideoHeightKey: outH,
+            ]
+            let input = AVAssetWriterInput(mediaType: .video, outputSettings: videoSettings)
+            input.expectsMediaDataInRealTime = false
+            let pba = AVAssetWriterInputPixelBufferAdaptor(
+                assetWriterInput: input,
+                sourcePixelBufferAttributes: [
+                    kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+                    kCVPixelBufferWidthKey as String: outW,
+                    kCVPixelBufferHeightKey as String: outH,
+                ])
+            writer.add(input)
+            writerInput = input
+            adaptor = pba
+
+            if audioReaderOutput != nil {
+                let aInput = AVAssetWriterInput(mediaType: .audio, outputSettings: nil, sourceFormatHint: audioFormatHint)
+                aInput.expectsMediaDataInRealTime = false
+                writer.add(aInput)
+                audioWriterInput = aInput
+            }
+
+            guard writer.startWriting() else { throw Self.err("writer failed: \(writer.error?.localizedDescription ?? "unknown")") }
+            writer.startSession(atSourceTime: .zero)
+            writerStarted = true
+        }
+
+        func append(_ image: CGImage) async throws {
+            guard let writerInput, let adaptor else { throw Self.err("writer not started") }
+            while !writerInput.isReadyForMoreMediaData {
+                try Task.checkCancellation()
+                try await Task.sleep(nanoseconds: 5_000_000)
+            }
+            guard let buffer = Self.makePixelBuffer(from: image, width: outW, height: outH) else {
+                throw Self.err("pixel buffer creation failed")
+            }
+            adaptor.append(buffer, withPresentationTime: presentationTime)
+            presentationTime = presentationTime + frameDuration
+            written += 1
+            progress(Double(written) / Double(estimatedFrameCount))
+        }
+
+        // Decode -> upscale -> write, one frame at a time (see file header for why this
+        // diverges from VideoInterpolator's buffer-the-whole-clip approach).
+        while let sample = videoReaderOutput.copyNextSampleBuffer() {
+            try Task.checkCancellation()
+            guard let pixelBuffer = CMSampleBufferGetImageBuffer(sample) else { continue }
+            let ciImage = CIImage(cvPixelBuffer: pixelBuffer)
+            guard let cg = ciContext.createCGImage(ciImage, from: ciImage.extent) else { continue }
+            let upscaled = try await upscaler.upscale(cg)
+            try Task.checkCancellation()
+            try startWriterIfNeeded(sampleWidth: upscaled.width, sampleHeight: upscaled.height)
+            try await append(upscaled)
+        }
+        guard writerStarted, let writerInput else { throw Self.err("source clip has no frames") }
+        writerInput.markAsFinished()
+
+        if let audioReaderOutput, let audioWriterInput {
+            while let sample = audioReaderOutput.copyNextSampleBuffer() {
+                try Task.checkCancellation()
+                while !audioWriterInput.isReadyForMoreMediaData {
+                    try await Task.sleep(nanoseconds: 5_000_000)
+                }
+                audioWriterInput.append(sample)
+            }
+            audioWriterInput.markAsFinished()
+        }
+
+        await writer.finishWriting()
+        if writer.status == .failed {
+            throw Self.err("writer failed: \(writer.error?.localizedDescription ?? "unknown")")
+        }
+    }
+
+    nonisolated private static func makePixelBuffer(from image: CGImage, width: Int, height: Int) -> CVPixelBuffer? {
+        var pixelBuffer: CVPixelBuffer?
+        let attrs: [String: Any] = [
+            kCVPixelBufferCGImageCompatibilityKey as String: true,
+            kCVPixelBufferCGBitmapContextCompatibilityKey as String: true,
+        ]
+        let status = CVPixelBufferCreate(kCFAllocatorDefault, width, height, kCVPixelFormatType_32BGRA, attrs as CFDictionary, &pixelBuffer)
+        guard status == kCVReturnSuccess, let buffer = pixelBuffer else { return nil }
+
+        CVPixelBufferLockBaseAddress(buffer, [])
+        defer { CVPixelBufferUnlockBaseAddress(buffer, []) }
+        guard let ctx = CGContext(
+            data: CVPixelBufferGetBaseAddress(buffer), width: width, height: height,
+            bitsPerComponent: 8, bytesPerRow: CVPixelBufferGetBytesPerRow(buffer),
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue
+        ) else { return nil }
+        ctx.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+        return buffer
+    }
+
+    private static func err(_ msg: String) -> NSError {
+        NSError(domain: "VideoUpscaler", code: 1, userInfo: [NSLocalizedDescriptionKey: msg])
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `apps/CoreAIStudio/Sources/VideoUpscaler.swift`: an AVFoundation frame-by-frame video
  upscale pipeline mirroring `VideoInterpolator`'s decode/encode/audio-passthrough/progress/
  cancellation structure, but processing each frame independently (no whole-clip buffering)
  since upscaling has no cross-frame dependency the way RIFE interpolation does.
- Introduces the `FrameUpscaler` protocol so `VideoUpscaler` depends on it, not on
  `UpscaleEngine` (AdcSR) concretely — a future PiperSR-based engine can conform the same way
  without touching `VideoUpscaler.swift` again.
- `UpscaleEngine` now conforms to `FrameUpscaler` via a small extension added to
  `UpscaleEngine.swift`, exposing its already-loaded `InferenceFunction` through the protocol's
  per-frame `upscale(_:)` signature.
- Fixes a real runtime crash surfaced by e2e testing: a nil-`outputSettings` (passthrough)
  `AVAssetWriterInput` for the audio track needs a `sourceFormatHint` on this SDK, or
  `writer.add(_:)` throws `NSInvalidArgumentException` ("please provide a format hint... to
  perform passthrough"). Note: `VideoInterpolator.swift` has the same nil-outputSettings pattern
  and is likely subject to the same crash, but fixing it is out of scope for this change.

## Test plan
- [x] `xcodegen generate` + `xcodebuild -scheme CoreAIStudio -sdk macosx -configuration Debug
      build` — zero errors (only pre-existing AVFoundation-deprecation warnings elsewhere).
- [x] Manual code review pass for correctness (actor isolation, error handling, cancellation).
- [x] e2e: throwaway harness instantiating `VideoUpscaler` with a no-op `FrameUpscaler` against
      a real ffmpeg-generated test clip (64x64, 10fps, 2s, with audio) — confirmed
      decode → upscale → encode → audio-passthrough produced a valid output file with matching
      duration and both video/audio streams, verified via `ffprobe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)