### PR TITLE
Add ConversionQueue: batch conversion queue data model for CoreAIStudio

### DIFF
--- a/apps/CoreAIStudio/Sources/ConversionQueue.swift
+++ b/apps/CoreAIStudio/Sources/ConversionQueue.swift
@@ -1,0 +1,244 @@
+// ConversionQueue — a HandBrake-style batch conversion queue: a coordination/data-model layer
+// that orchestrates VideoUpscaler (upscale jobs) and VideoInterpolator (interpolate jobs, see
+// that file for the RIFE/multiplier pipeline it wraps). No Core AI / AVFoundation logic lives
+// here — this file only sequences jobs and bridges each engine's own @Published `status` into a
+// per-item QueueItemStatus that a future queue UI (a separate work unit) can observe.
+//
+// Output naming/location matches VideoView.convert()'s existing save-panel convention in
+// ContentView.swift (`_<multiplier>x.mp4` next to the chosen name) — since the queue has no save
+// panel to prompt per item, outputs are placed next to the source file with a suffix before the
+// extension: `_2x`/`_4x` for interpolation (mirroring `_\(multiplier)x`), `_upscaled` for
+// upscale jobs.
+
+import Foundation
+
+enum QueueItemKind: Equatable {
+    case upscaleVideo
+    case interpolateVideo(multiplier: Int)  // 2 or 4, matches VideoInterpolator's multiplier concept
+
+    /// Suffix inserted before the source's extension when deriving a default output URL.
+    var outputSuffix: String {
+        switch self {
+        case .upscaleVideo: return "_upscaled"
+        case .interpolateVideo(let multiplier): return "_\(multiplier)x"
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .upscaleVideo: return "Upscale"
+        case .interpolateVideo(let multiplier): return "Interpolate ×\(multiplier)"
+        }
+    }
+}
+
+enum QueueItemStatus: Equatable {
+    case pending
+    case running(progress: Double)
+    case done(outputURL: URL)
+    case failed(String)
+
+    var isBusy: Bool {
+        if case .running = self { return true }
+        return false
+    }
+}
+
+struct QueueItem: Identifiable {
+    let id: UUID
+    var sourceURL: URL
+    var kind: QueueItemKind
+    var status: QueueItemStatus
+    /// Where the output will be (or was) written. Filled in with a derived default at `add`
+    /// time; a future UI could let the user override it before the item runs.
+    var outputURL: URL
+
+    var displayName: String { sourceURL.lastPathComponent }
+
+    init(id: UUID = UUID(), sourceURL: URL, kind: QueueItemKind, outputURL: URL? = nil, status: QueueItemStatus = .pending) {
+        self.id = id
+        self.sourceURL = sourceURL
+        self.kind = kind
+        self.status = status
+        self.outputURL = outputURL ?? QueueItem.defaultOutputURL(sourceURL: sourceURL, kind: kind)
+    }
+
+    static func defaultOutputURL(sourceURL: URL, kind: QueueItemKind) -> URL {
+        let base = sourceURL.deletingPathExtension().lastPathComponent + kind.outputSuffix
+        return sourceURL.deletingLastPathComponent()
+            .appendingPathComponent(base)
+            .appendingPathExtension("mp4")
+    }
+}
+
+@MainActor
+final class ConversionQueue: ObservableObject {
+    @Published private(set) var items: [QueueItem] = []
+    @Published private(set) var isRunning: Bool = false
+
+    private let videoUpscaler: VideoUpscaler
+    private let videoInterpolator: VideoInterpolator
+
+    /// Set by `cancelCurrent()`, observed by the polling loop in `bridgeAndAwait` — the engines
+    /// themselves reset their own @Published status back to `.idle` on cancel (see
+    /// VideoInterpolator.cancel()), so polling status alone can't distinguish "cancelled" from
+    /// "never started"; this flag disambiguates.
+    private var cancelRequested = false
+
+    init(videoUpscaler: VideoUpscaler, videoInterpolator: VideoInterpolator) {
+        self.videoUpscaler = videoUpscaler
+        self.videoInterpolator = videoInterpolator
+    }
+
+    // MARK: - Editing
+
+    func add(sourceURL: URL, kind: QueueItemKind) {
+        items.append(QueueItem(sourceURL: sourceURL, kind: kind))
+    }
+
+    func remove(at index: Int) {
+        guard items.indices.contains(index) else { return }
+        if isRunning, items[index].status.isBusy {
+            cancelCurrent()
+        }
+        items.remove(at: index)
+    }
+
+    func remove(id: UUID) {
+        guard let index = items.firstIndex(where: { $0.id == id }) else { return }
+        remove(at: index)
+    }
+
+    func move(from source: IndexSet, to destination: Int) {
+        items.move(fromOffsets: source, toOffset: destination)
+    }
+
+    func clearCompleted() {
+        items.removeAll { item in
+            if case .done = item.status { return true }
+            return false
+        }
+    }
+
+    // MARK: - Running
+
+    /// Processes items sequentially, one at a time, updating each item's status in place as it
+    /// runs. If one item fails, the queue moves on to the next rather than aborting entirely.
+    /// Looks items up by id (not index) at each step so concurrent `move`/`remove` calls from a
+    /// queue-editing UI can't desync this loop from a shifting array.
+    func start() async {
+        guard !isRunning else { return }
+        isRunning = true
+        defer { isRunning = false }
+
+        while let id = items.first(where: { if case .pending = $0.status { return true }; return false })?.id {
+            await runItem(id: id)
+        }
+    }
+
+    func cancelCurrent() {
+        guard isRunning else { return }
+        cancelRequested = true
+        videoUpscaler.cancel()
+        videoInterpolator.cancel()
+    }
+
+    // MARK: - Per-item execution
+
+    private func runItem(id: UUID) async {
+        guard let index = items.firstIndex(where: { $0.id == id }) else { return }
+        items[index].status = .running(progress: 0)
+        let item = items[index]
+
+        switch item.kind {
+        case .upscaleVideo:
+            await runUpscale(item: item, id: id)
+        case .interpolateVideo(let multiplier):
+            await runInterpolate(item: item, id: id, multiplier: multiplier)
+        }
+    }
+
+    private func runUpscale(item: QueueItem, id: UUID) async {
+        videoUpscaler.loadSource(item.sourceURL)
+        videoUpscaler.run(sourceURL: item.sourceURL, outputURL: item.outputURL)
+        await bridgeAndAwait(id: id) { [videoUpscaler] in
+            switch videoUpscaler.status {
+            case .idle, .analyzing:
+                return nil
+            case .working(let progress):
+                return .running(progress: progress)
+            case .done(let url):
+                return .done(outputURL: url)
+            case .error(let message):
+                return .failed(message)
+            }
+        }
+    }
+
+    private func runInterpolate(item: QueueItem, id: UUID, multiplier: Int) async {
+        videoInterpolator.loadSource(item.sourceURL)
+        videoInterpolator.run(sourceURL: item.sourceURL, multiplier: multiplier, outputURL: item.outputURL)
+        await bridgeAndAwait(id: id) { [videoInterpolator] in
+            switch videoInterpolator.status {
+            case .idle, .analyzing:
+                return nil
+            case .working(let progress):
+                return .running(progress: progress)
+            case .done(let url):
+                return .done(outputURL: url)
+            case .error(let message):
+                return .failed(message)
+            }
+        }
+    }
+
+    /// Polls `poll()` until it reports a terminal QueueItemStatus (`.done`/`.failed`), writing
+    /// each intermediate status into the item (looked up by id) as it goes. `poll` returning nil
+    /// means the underlying engine hasn't started producing progress yet (still
+    /// idle/analyzing). If the item is removed from the queue mid-run, the loop exits quietly
+    /// (there's nothing left to update) rather than looping forever.
+    ///
+    /// `sawRunning` guards against a real hazard in both engines' `run(...)`: it's a fire-and-
+    /// forget call that silently no-ops if its own readiness guard fails (e.g. VideoInterpolator
+    /// requires `engine.isReady`), *without* touching `status` — so immediately after such a
+    /// no-op, `status` is still whatever the *previous* job on this engine left behind (idle, or
+    /// even a stale `.done`/`.error` from the last item). Without this guard we'd either hang
+    /// forever polling a stationary `.idle`, or worse, misattribute a stale terminal result to
+    /// this item. We only accept a terminal status once we've first observed `.running` for this
+    /// job; if that never happens within `startGrace`, we fail this item outright instead of
+    /// blocking the rest of the queue.
+    private func bridgeAndAwait(id: UUID, poll: () -> QueueItemStatus?) async {
+        cancelRequested = false
+        var sawRunning = false
+        var waitedWithoutStart: UInt64 = 0
+        let startGraceNanos: UInt64 = 5_000_000_000
+        let pollIntervalNanos: UInt64 = 50_000_000
+
+        while true {
+            guard let index = items.firstIndex(where: { $0.id == id }) else { return }
+            if cancelRequested {
+                items[index].status = .failed("Cancelled")
+                cancelRequested = false
+                return
+            }
+            if let status = poll() {
+                if case .running = status { sawRunning = true }
+                if sawRunning {
+                    items[index].status = status
+                    switch status {
+                    case .done, .failed: return
+                    default: break
+                    }
+                }
+            }
+            if !sawRunning {
+                waitedWithoutStart += pollIntervalNanos
+                if waitedWithoutStart >= startGraceNanos {
+                    items[index].status = .failed("Job never started — engine not ready?")
+                    return
+                }
+            }
+            try? await Task.sleep(nanoseconds: pollIntervalNanos)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `apps/CoreAIStudio/Sources/ConversionQueue.swift` — a `@MainActor` `ObservableObject` coordination/data-model layer for a HandBrake-style batch conversion queue.
- Orchestrates `VideoUpscaler` (upscale jobs) and `VideoInterpolator` (interpolate jobs, RIFE multiplier) with no Core AI / AVFoundation logic of its own.
- `QueueItem`/`QueueItemKind`/`QueueItemStatus` model pending/running/done/failed items, with a default output URL derived next to the source (`_upscaled` / `_2x` / `_4x` suffix), matching `VideoView.convert()`'s existing `_<multiplier>x.mp4` naming convention in `ContentView.swift`.
- `add`, `remove(at:)`, `remove(id:)`, `move(from:to:)` (matches SwiftUI `List.onMove`), `clearCompleted()`.
- `start()` processes items sequentially, looked up **by id** (not index) at each step so it's robust to concurrent `move`/`remove` from a queue-editing UI. If one item fails, the queue moves on to the next rather than aborting.
- `cancelCurrent()` cancels the in-flight item only.
- `bridgeAndAwait()` guards against a real hazard verified in `VideoInterpolator.run()`'s source: its readiness guard (`engine.isReady && multiplier >= 2`) returns early **without touching `status`** on failure, so naively polling could either hang forever (status stuck at `.idle`) or misattribute a stale `.done`/`.error` left over from the *previous* item. The bridge only accepts a terminal status after first observing `.running`, and times out (fails the item, not the queue) if that never happens.

## Dependency note
`VideoUpscaler.swift` is being built in a sibling work unit in parallel and is **not yet present** in this branch. `ConversionQueue.swift` is written against the documented fallback contract:
```swift
@MainActor
final class VideoUpscaler: ObservableObject {
    enum Status: Equatable { case idle, analyzing, working(progress: Double), done(URL), error(String) }
    @Published private(set) var status: Status
    func loadSource(_ url: URL)
    func run(sourceURL: URL, outputURL: URL)
    func cancel()
}
```
Verified `ConversionQueue.swift` type-checks correctly by temporarily stubbing `VideoUpscaler` locally (build succeeded with zero errors), then deleted the stub before this commit — confirmed via `git status` and a rebuild that now fails with **only** the expected `cannot find type 'VideoUpscaler' in scope` errors, nothing else. Once the sibling PR lands `VideoUpscaler.swift`, this file should compile as-is.

`ContentView.swift` is intentionally **not** wired to this queue in this unit — that's a separate follow-up.

## Test plan
- [x] `xcodegen generate` + `xcodebuild ... build` — zero errors except the expected missing `VideoUpscaler` symbol (documented above).
- [x] Verified compilation end-to-end with a temporary local `VideoUpscaler` stub matching the fallback contract (deleted before commit — not part of this diff).
- [x] Ran a throwaway `#if DEBUG` self-test harness (temporarily wired into `CoreAIStudioApp.init()`, then removed) exercising `add`/`move`/`remove` and asserting `items` and derived `outputURL` update correctly; the app ran without any assertion trap.
- [ ] Manual UI verification — not applicable yet, `ContentView.swift` isn't wired to this queue (separate unit).