### PR TITLE
pocket-tts (Kyutai): Core AI port with model card, recipe, and conversion scripts

### DIFF
--- a/conversion/pocket-tts/export_flow_decoder.py
+++ b/conversion/pocket-tts/export_flow_decoder.py
@@ -1,0 +1,136 @@
+"""Flow decoder (graph d) -> Core AI, gated on the exact oracle fixture.
+
+    cond [1,1024] + noise [1,32]  ->  latent [1,32]
+
+Pure function, no state. `s`/`t` are baked at the upstream default
+`lsd_decode_steps = 1` (`pocket_tts/default_parameters.py:3`), i.e. one Euler step
+from s=0 to t=1. The 8-step variant FluidAudio ships exists and would need `s`/`t`
+as inputs (or an unrolled fused graph) — not chased here.
+
+`oracle['step/noise'] -> oracle['step/latent']` at a fixed `oracle['step/cond']` is
+an exact fixture: the oracle clones the noise before `lsd_decode` mutates it in place.
+
+Run (export venv):
+    HF_HOME=$PWD/weights/hf DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer \
+      .venv-export/bin/python conversion/export_flow_decoder.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+from torch.nn import functional as F
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+sys.path.insert(0, str(HERE))
+
+from flowlm_graphs import FlowDecoder  # noqa: E402
+
+
+def report(tag, got, gold) -> bool:
+    cos = F.cosine_similarity(got, gold, dim=-1)
+    ok = cos.min() > 0.999
+    print(
+        f"[{tag}] steps {cos.shape[0]}  cos mean {cos.mean():.6f} min {cos.min():.6f}  "
+        f"max|Δ| {(got - gold).abs().max():.3e}  -> {'PASS' if ok else 'FAIL'}"
+    )
+    return ok
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--oracle", default="oracle/orc_a.npz")
+    ap.add_argument("--dtype", choices=["float32", "float16"], default="float32")
+    ap.add_argument("--artifacts", default="artifacts")
+    ap.add_argument("--skip-export", action="store_true")
+    args = ap.parse_args()
+
+    torch.set_num_threads(1)
+    dtype = torch.float16 if args.dtype == "float16" else torch.float32
+    orc = np.load(ROOT / args.oracle)
+    cond = torch.from_numpy(orc["step/cond"])       # [N,1024]
+    noise = torch.from_numpy(orc["step/noise"])     # [N,32]
+    gold = torch.from_numpy(orc["step/latent"])     # [N,32]
+    n = cond.shape[0]
+
+    from pocket_tts import TTSModel
+
+    model = TTSModel.load_model().eval()
+    dec = FlowDecoder(model.flow_lm).eval()
+
+    with torch.no_grad():
+        eager = torch.cat([dec(cond[i : i + 1], noise[i : i + 1]) for i in range(n)])
+    if not report("eager fp32", eager, gold):
+        print("❌ flow-decoder re-author DIVERGES — fix before export")
+        raise SystemExit(1)
+    print("✅ eager rewrite reproduces lsd_decode(num_steps=1)")
+    if args.skip_export:
+        return
+
+    import asyncio
+
+    import coreai.runtime as rt
+    from coreai_models.export.macos import export_to_coreai
+
+    dec = dec.to(dtype)
+    example = {
+        "cond": torch.zeros(1, 1024, dtype=dtype),
+        "noise": torch.zeros(1, 32, dtype=dtype),
+    }
+    print(f"[export] flow decoder ({args.dtype}, 1 LSD step) -> Core AI ...", flush=True)
+    prog = export_to_coreai(
+        dec,
+        example,
+        dynamic_shapes=None,
+        input_names=("cond", "noise"),
+        output_names=("latent",),
+        state_names=None,
+        externalize_modules=[],
+    )
+    prog.optimize()
+    art = ROOT / args.artifacts
+    art.mkdir(exist_ok=True)
+    path = art / f"flow_decoder_{args.dtype}_lsd1.aimodel"
+    shutil.rmtree(path, ignore_errors=True)
+    meta = rt.AIModelAssetMetadata()
+    meta.license = "cc-by-4.0"
+    prog.save_asset(path, meta)
+    sz = sum(f.stat().st_size for f in path.rglob("*") if f.is_file()) / 1e6
+    print(f"[save] {path.name} ({sz:.1f} MB)")
+
+    np_dtype = np.float16 if dtype is torch.float16 else np.float32
+
+    async def gate(unit):
+        opts = (
+            rt.SpecializationOptions.cpu_only()
+            if unit == "cpu"
+            else rt.SpecializationOptions.from_preferred_compute_unit_kind(
+                getattr(rt.ComputeUnitKind, unit)()
+            )
+        )
+        fn = (await rt.AIModel.load(str(path), opts)).load_function("main")
+        outs = []
+        for i in range(n):
+            r = await fn(
+                {
+                    "cond": rt.NDArray(np.ascontiguousarray(cond[i : i + 1].numpy().astype(np_dtype))),
+                    "noise": rt.NDArray(
+                        np.ascontiguousarray(noise[i : i + 1].numpy().astype(np_dtype))
+                    ),
+                }
+            )
+            outs.append(torch.from_numpy(r["latent"].numpy().astype(np.float32)).reshape(-1))
+        return report(f"gate {unit}", torch.stack(outs), gold)
+
+    for unit in ("cpu", "gpu"):
+        asyncio.run(gate(unit))
+
+
+if __name__ == "__main__":
+    main()

--- a/conversion/pocket-tts/export_flowlm.py
+++ b/conversion/pocket-tts/export_flowlm.py
@@ -1,0 +1,272 @@
+"""Flow-LM prefill + AR step -> ONE Core AI multifunction asset, gated on the oracle.
+
+    prefill(text_emb [1,16,1024], pos [1])            -> cond [1,1024]   |  shared
+    step   (latent_in [1,1,32], is_bos [1], pos [1])  -> cond, eos_logit |  k/v state
+
+Both entrypoints are staged into one `TorchConverter`, so the 75.5 M transformer
+weights are stored once and both functions mutate the SAME `k_cache`/`v_cache`
+Core AI states (no host KV round-trip).
+
+Gate ladder:
+  1. eager  : seed the state with the shipped voice conditioning, prefill the oracle's
+              text embeddings, then teacher-force all 32 AR steps on the oracle's own
+              latents. `cond` and `eos_logit` must match `oracle['step/*']`.
+  2. engine : the same replay driving the .aimodel, cpu then gpu.
+
+Run (export venv):
+    HF_HOME=$PWD/weights/hf DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer \
+      .venv-export/bin/python conversion/export_flowlm.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+from torch.nn import functional as F
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+sys.path.insert(0, str(HERE))
+
+from flowlm_graphs import (  # noqa: E402
+    LDIM,
+    S_MAX,
+    STATE_NAMES,
+    T_PRE,
+    FlowLMPrefill,
+    FlowLMStep,
+    build_kv_state,
+)
+
+VOICE_LEN = 126     # the shipped `alba` conditioning state, as pre-baked in the checkpoint
+
+
+def seed_voice_state(state: dict, orc, dtype=torch.float32) -> int:
+    """Copy the oracle's captured voice KV (upstream layout [2,1,L,H,D]) into the
+    packed [layer,1,H,S,D] Core AI state. Returns the resulting absolute position."""
+    offs = set()
+    for i in range(6):
+        c = torch.from_numpy(orc[f"voice/transformer.layers.{i}.self_attn/cache"])
+        off = int(orc[f"voice/transformer.layers.{i}.self_attn/offset"].reshape(-1)[0])
+        offs.add(off)
+        n = c.shape[2]
+        state["k_cache"][i, 0, :, :n] = c[0, 0].permute(1, 0, 2).to(dtype)
+        state["v_cache"][i, 0, :, :n] = c[1, 0].permute(1, 0, 2).to(dtype)
+    assert len(offs) == 1, f"voice offsets disagree across layers: {offs}"
+    return offs.pop()
+
+
+def pad_text(text_emb: torch.Tensor) -> torch.Tensor:
+    t = text_emb.shape[1]
+    assert t <= T_PRE, f"text chunk {t} exceeds the T_PRE={T_PRE} prefill width"
+    return F.pad(text_emb, (0, 0, 0, T_PRE - t))
+
+
+def replay_eager(prefill, step, orc, dtype=torch.float32):
+    """Teacher-forced replay in torch: voice state -> prefill -> 32 AR steps."""
+    st = build_kv_state(dtype)
+    pos = seed_voice_state(st, orc, dtype)
+    text = torch.from_numpy(orc["prefill/text_embeddings"]).to(dtype)
+    t_real = text.shape[1]
+    with torch.no_grad():
+        prefill(pad_text(text), torch.tensor([pos], dtype=torch.int32), st["k_cache"], st["v_cache"])
+        pos += t_real
+        gold_lat = torch.from_numpy(orc["step/latent"])
+        n = gold_lat.shape[0]
+        conds, eoss = [], []
+        for i in range(n):
+            lat = (
+                torch.zeros(1, 1, LDIM, dtype=dtype)
+                if i == 0
+                else gold_lat[i - 1].reshape(1, 1, LDIM).to(dtype)
+            )
+            c, e = step(
+                lat,
+                torch.tensor([1.0 if i == 0 else 0.0], dtype=dtype),
+                torch.tensor([pos + i], dtype=torch.int32),
+                st["k_cache"],
+                st["v_cache"],
+            )
+            conds.append(c.reshape(-1).float())
+            eoss.append(e.reshape(-1).float())
+    return torch.stack(conds), torch.stack(eoss)
+
+
+def report(tag, got_cond, got_eos, orc) -> bool:
+    gc_ = torch.from_numpy(orc["step/cond"])
+    ge = torch.from_numpy(orc["step/eos_logit"])
+    cos = F.cosine_similarity(got_cond, gc_, dim=-1)
+    d_eos = (got_eos - ge).abs().max()
+    # the host applies `> -4.0`; a flipped sign decision is a hard failure
+    flips = int(((got_eos > -4.0) != (ge > -4.0)).sum())
+    ok = cos.min() > 0.999 and flips == 0
+    print(
+        f"[{tag}] steps {cos.shape[0]}  cond cos mean {cos.mean():.6f} min {cos.min():.6f}  "
+        f"max|Δcond| {(got_cond - gc_).abs().max():.3e}  max|Δeos| {d_eos:.3e}  "
+        f"eos-decision flips {flips}  -> {'PASS' if ok else 'FAIL'}"
+    )
+    return ok
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--oracle", default="oracle/orc_a.npz")
+    ap.add_argument("--dtype", choices=["float32", "float16"], default="float32")
+    ap.add_argument("--artifacts", default="artifacts")
+    ap.add_argument("--skip-export", action="store_true")
+    args = ap.parse_args()
+
+    torch.set_num_threads(1)
+    dtype = torch.float16 if args.dtype == "float16" else torch.float32
+    orc = np.load(ROOT / args.oracle)
+
+    from pocket_tts import TTSModel
+
+    model = TTSModel.load_model().eval()
+    prefill = FlowLMPrefill(model.flow_lm).eval()
+    step = FlowLMStep(model.flow_lm).eval()
+
+    # ---- 1. eager gate (always fp32 — this checks the re-author, not the precision)
+    c, e = replay_eager(prefill, step, orc, torch.float32)
+    if not report("eager fp32", c, e, orc):
+        print("❌ static-KV re-author DIVERGES — fix before export")
+        raise SystemExit(1)
+    print("✅ eager rewrite reproduces the flow-LM AR step")
+    if args.skip_export:
+        return
+
+    # ---- 2. export: two entrypoints, one weight set, one shared state -------
+    import asyncio
+
+    import coreai.runtime as rt
+    import coreai_torch
+    from coreai_models.export.macos import _EXTERNALIZE_SPECS
+    from coreai_models.export.mlir_ops import (
+        register_custom_torch_lowering,
+        remove_functionalization,
+    )
+
+    prefill, step = prefill.to(dtype), step.to(dtype)
+    st_p, st_s = build_kv_state(dtype), build_kv_state(dtype)
+    ref_p = {
+        "text_emb": torch.zeros(1, T_PRE, 1024, dtype=dtype),
+        "pos": torch.tensor([VOICE_LEN], dtype=torch.int32),
+        **st_p,
+    }
+    ref_s = {
+        "latent_in": torch.zeros(1, 1, LDIM, dtype=dtype),
+        "is_bos": torch.zeros(1, dtype=dtype),
+        "pos": torch.tensor([VOICE_LEN + T_PRE], dtype=torch.int32),
+        **st_s,
+    }
+    # SDPA stays inlined: the externalized composite carries its own mask/window
+    # attrs and we hand it an explicit bool mask over the full cache.
+    specs = [s for s in _EXTERNALIZE_SPECS if s.composite_op_name != "scaled_dot_product_attention"]
+
+    def mk(ref):
+        def export_fn(m):
+            with torch.no_grad():
+                ep = torch.export.export(m, args=(), kwargs=ref, dynamic_shapes=None)
+            ep = ep.run_decompositions(coreai_torch.get_decomp_table())
+            remove_functionalization(ep)
+            return ep
+
+        return export_fn
+
+    print(f"[export] flow-LM prefill(T={T_PRE}) + step, S={S_MAX}, {args.dtype} ...", flush=True)
+    conv = coreai_torch.TorchConverter()
+    conv.add_pytorch_module(
+        prefill,
+        export_fn=mk(ref_p),
+        externalize_modules=specs,
+        input_names=("text_emb", "pos"),
+        output_names=("cond",),
+        state_names=STATE_NAMES,
+        entrypoint_name="prefill",
+    )
+    conv.add_pytorch_module(
+        step,
+        export_fn=mk(ref_s),
+        externalize_modules=specs,
+        input_names=("latent_in", "is_bos", "pos"),
+        output_names=("cond", "eos_logit"),
+        state_names=STATE_NAMES,
+        entrypoint_name="step",
+    )
+    register_custom_torch_lowering(conv)
+    prog = conv.to_coreai()
+    prog.optimize()
+
+    art = ROOT / args.artifacts
+    art.mkdir(exist_ok=True)
+    path = art / f"flowlm_{args.dtype}_s{S_MAX}.aimodel"
+    shutil.rmtree(path, ignore_errors=True)
+    meta = rt.AIModelAssetMetadata()
+    meta.license = "cc-by-4.0"
+    prog.save_asset(path, meta)
+    sz = sum(f.stat().st_size for f in path.rglob("*") if f.is_file()) / 1e6
+    print(f"[save] {path.name} ({sz:.1f} MB)")
+
+    # ---- 3. engine gate ----------------------------------------------------
+    np_dtype = np.float16 if dtype is torch.float16 else np.float32
+
+    async def gate(unit):
+        opts = (
+            rt.SpecializationOptions.cpu_only()
+            if unit == "cpu"
+            else rt.SpecializationOptions.from_preferred_compute_unit_kind(
+                getattr(rt.ComputeUnitKind, unit)()
+            )
+        )
+        m = await rt.AIModel.load(str(path), opts)
+        print(f"  functions: {m.function_names}")
+        fp, fs = m.load_function("prefill"), m.load_function("step")
+
+        st = build_kv_state(dtype)
+        pos = seed_voice_state(st, orc, dtype)
+        state = {k: rt.NDArray(np.ascontiguousarray(v.numpy())) for k, v in st.items()}
+
+        text = torch.from_numpy(orc["prefill/text_embeddings"]).to(dtype)
+        t_real = text.shape[1]
+        await fp(
+            inputs={
+                "text_emb": rt.NDArray(np.ascontiguousarray(pad_text(text).numpy())),
+                "pos": rt.NDArray(np.ascontiguousarray(np.array([pos], np.int32))),
+            },
+            state=state,
+        )
+        pos += t_real
+
+        gold_lat = torch.from_numpy(orc["step/latent"])
+        conds, eoss = [], []
+        for i in range(gold_lat.shape[0]):
+            lat = (
+                np.zeros((1, 1, LDIM), np_dtype)
+                if i == 0
+                else gold_lat[i - 1].reshape(1, 1, LDIM).numpy().astype(np_dtype)
+            )
+            r = await fs(
+                inputs={
+                    "latent_in": rt.NDArray(np.ascontiguousarray(lat)),
+                    "is_bos": rt.NDArray(
+                        np.ascontiguousarray(np.array([1.0 if i == 0 else 0.0], np_dtype))
+                    ),
+                    "pos": rt.NDArray(np.ascontiguousarray(np.array([pos + i], np.int32))),
+                },
+                state=state,
+            )
+            conds.append(torch.from_numpy(r["cond"].numpy().astype(np.float32)).reshape(-1))
+            eoss.append(torch.from_numpy(r["eos_logit"].numpy().astype(np.float32)).reshape(-1))
+        return report(f"gate {unit}", torch.stack(conds), torch.stack(eoss), orc)
+
+    for unit in ("cpu", "gpu"):
+        asyncio.run(gate(unit))
+
+
+if __name__ == "__main__":
+    main()

--- a/conversion/pocket-tts/export_mimi_decoder.py
+++ b/conversion/pocket-tts/export_mimi_decoder.py
@@ -1,0 +1,365 @@
+"""Mimi decoder -> Core AI: functional state-in/state-out rewrite, eager gate, export, engine gate.
+
+One call decodes ONE 12.5 Hz latent frame into 1920 PCM samples at 24 kHz:
+
+    latent [1,512,1] (post-quantizer)  +  12 state tensors
+        -> pcm [1,1,1920]              +  12 updated state tensors
+
+Upstream mutates its streaming state in place (`state["previous"][:] = ...`,
+`cache[0,:,off:off+k] = k`) which torch.export cannot see through, so every stateful
+primitive is re-expressed functionally:
+
+  * StreamingConv1d          -> cat(prev, x) -> conv -> tail slice is the new prev
+  * StreamingConvTranspose1d -> convtr -> overlap-add head, tail (minus bias) is new partial
+  * KV cache                 -> fixed-capacity SHIFT REGISTER (cat + slice), no scatter,
+                                no .item(). Capacity 272 >= context(250) + 16 new positions,
+                                which makes the ring mathematically exact for this graph.
+                                Ring is zero-initialised, NOT NaN-initialised: upstream slices
+                                the NaN tail away, but a masked SDPA still multiplies V by 0
+                                and 0 * NaN = NaN.
+
+Gate ladder (zoo style):
+  1. eager  : 31-frame replay on the oracle latents vs oracle['mimi/out'] -> must be ~exact
+  2. engine : same replay driving the .aimodel, cosine per frame, cpu then gpu
+"""
+
+from __future__ import annotations
+
+import argparse, shutil
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.nn as nn
+from torch.nn import functional as F
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+RING = 272          # >= context 250 + 16 positions written per call
+CTX = 250
+STEPS = 16          # encoder frames per 12.5 Hz latent (200 Hz / 12.5 Hz)
+
+
+# --------------------------------------------------------------------- primitives
+def elu(x: torch.Tensor) -> torch.Tensor:
+    """ELU(alpha=1). aten.elu has no Core AI lowering on coreai-torch 0.4.1, so it is
+    written out; expm1 keeps this bit-identical to torch's own kernel."""
+    return torch.where(x > 0, x, torch.expm1(x))
+
+
+def sconv(conv: nn.Conv1d, x: torch.Tensor, prev: torch.Tensor):
+    """StreamingConv1d, pad_mode='constant' (the only mode on the decode path)."""
+    tp = prev.shape[-1]
+    if tp == 0:
+        return conv(x), prev
+    xc = torch.cat([prev, x], dim=-1)
+    return conv(xc), xc[..., -tp:]
+
+
+def sconvtr(convtr: nn.ConvTranspose1d, x: torch.Tensor, partial: torch.Tensor):
+    y = convtr(x)
+    pt = partial.shape[-1]
+    if pt == 0:
+        return y, partial
+    y = torch.cat([y[..., :pt] + partial, y[..., pt:]], dim=-1)
+    tail = y[..., -pt:]
+    if convtr.bias is not None:
+        tail = tail - convtr.bias[:, None]
+    return y[..., :-pt], tail
+
+
+def apply_rope(q, k, offset, max_period=10000.0):
+    """Verbatim port of modules/rope.py with a tensor offset."""
+    B, T, H, D = q.shape
+    ds = torch.arange(D // 2, device=q.device, dtype=torch.float32)
+    freqs = torch.exp(ds * (-float(np.log(max_period)) * 2 / D))
+    ts = torch.arange(T, device=q.device, dtype=torch.float32) + offset.to(torch.float32)
+    ts = ts.view(-1, 1, 1)
+    q = q.view(B, T, H, D // 2, 2)
+    k = k.view(B, T, H, D // 2, 2)
+    qr, qi = q[..., 0].float(), q[..., 1].float()
+    kr, ki = k[..., 0].float(), k[..., 1].float()
+    rotr, roti = torch.cos(freqs * ts), torch.sin(freqs * ts)
+    qo = torch.stack([(qr * rotr - qi * roti), (qr * roti + qi * rotr)], dim=-1)
+    ko = torch.stack([(kr * rotr - ki * roti), (kr * roti + ki * rotr)], dim=-1)
+    return qo.view(B, T, H, D).to(q.dtype), ko.view(B, T, H, D).to(k.dtype)
+
+
+class RingAttention(nn.Module):
+    """StreamingMultiheadAttention with a shift-register KV cache."""
+
+    def __init__(self, src, heads: int):
+        super().__init__()
+        self.in_proj = src.in_proj
+        self.out_proj = src.out_proj
+        self.h = heads
+        self.d = src.dim_per_head
+
+    def forward(self, x, cache, offset):
+        b, t, _ = x.shape
+        packed = self.in_proj(x).view(b, t, 3, self.h, self.d)
+        q, k, v = torch.unbind(packed, dim=2)
+        q, k = apply_rope(q, k, offset)
+        new = torch.stack([k, v], dim=0)                       # [2,b,t,h,d]
+        cache = torch.cat([cache[:, :, t:], new], dim=2)       # shift-append
+        k_attn = cache[0].permute(0, 2, 1, 3)
+        v_attn = cache[1].permute(0, 2, 1, 3)
+        # absolute positions of the ring slots and of the queries
+        pos_k = offset.view(1, 1) + t - RING + torch.arange(RING, device=x.device).view(1, -1)
+        pos_q = offset.view(1, 1) + torch.arange(t, device=x.device).view(1, -1)
+        delta = pos_q[:, :, None] - pos_k[:, None, :]
+        mask = (pos_k[:, None, :] >= 0) & (delta >= 0) & (delta < CTX)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k_attn, v_attn, mask[:, None])
+        y = y.transpose(1, 2).reshape(b, t, self.h * self.d)
+        return self.out_proj(y), cache
+
+
+class MimiDecoderStep(nn.Module):
+    """upsample_mode:
+      'convtr' — upstream form, ConvTranspose1d(512,512,k=32,s=16,groups=512).
+      'outer'  — equivalent rewrite valid because T==1 and groups==channels: the
+                 transposed conv degenerates to a per-channel outer product
+                 out[c,:] = x[c,0] * W[c,0,:]. Exists because stride>=8 transposed
+                 convs are miscomputed by the Core AI cpu_only delegate (see
+                 repro_convtr_cpu.py); this form has no ConvTranspose1d at all.
+
+    fold_front (M2): take the RAW flow-LM latent [1,32] and do the
+    `latent * emb_std + emb_mean` rescale plus the quantizer `output_proj`
+    (Conv1d 32->512, k=1, bias-free — asserted) in-graph, deleting the last
+    host-side tensor math. Verified bit-exact against upstream's
+    `mimi.quantizer((lat*std+mean).transpose(-1,-2))` before adoption.
+
+    graph_state (M2): the 12 streaming-state tensors become Core AI in-graph
+    state (`state_names=`) instead of round-tripping through the host every
+    frame. The forward computes exactly the same new values and then commits
+    them with in-place `copy_` on the state inputs (torch.export records these
+    as user-input mutations; `remove_functionalization` re-materialises them,
+    same mechanics as the flow-LM KV). Chunk-boundary semantics are untouched:
+    the host owns the buffers for the whole run and never resets them, which is
+    the "Mimi state is NEVER reset across chunks" invariant by construction.
+    """
+
+    def __init__(self, mimi, upsample_mode: str = "convtr",
+                 fold_front: dict | None = None, graph_state: bool = False):
+        super().__init__()
+        self.upsample_mode = upsample_mode
+        self.graph_state = graph_state
+        self.fold = fold_front is not None
+        if self.fold:
+            self.register_buffer("emb_std", fold_front["emb_std"].detach().clone())
+            self.register_buffer("emb_mean", fold_front["emb_mean"].detach().clone())
+            self.register_buffer("proj_w", fold_front["proj_w"].detach().clone())
+        self.up = mimi.upsample.convtr.convtr
+        layers = mimi.decoder_transformer.transformer.layers
+        assert mimi.decoder_transformer.input_proj is None
+        self.attn = nn.ModuleList([RingAttention(l.self_attn, l.self_attn.num_heads) for l in layers])
+        self.layers = layers
+        self.m = mimi.decoder.model
+
+    def _tlayer(self, i, x, cache, offset):
+        l = self.layers[i]
+        upd, cache = self.attn[i](l.norm1(x), cache, offset)
+        x = x + l.layer_scale_1(upd)
+        x = x + l.layer_scale_2(l.linear2(F.gelu(l.linear1(l.norm2(x)))))
+        return x, cache
+
+    def _resnet(self, blk, x, prev):
+        v = elu(x)
+        v, prev = sconv(blk.block[1].conv, v, prev)
+        v = elu(v)
+        v = blk.block[3].conv(v)          # kernel 1 -> no history
+        return x + v, prev
+
+    def _upsample(self, latent, up_p):
+        if self.upsample_mode == "outer":
+            # latent [1,512,1] -> [1,512,32] without a ConvTranspose1d
+            y = latent * self.up.weight[:, 0, :].unsqueeze(0)
+        else:
+            y = self.up(latent)
+        pt = up_p.shape[-1]
+        y = torch.cat([y[..., :pt] + up_p, y[..., pt:]], dim=-1)
+        return y[..., :-pt], y[..., -pt:]
+
+    def forward(self, latent, up_p, kv0, kv1, offset,
+                c0, c2, c3, c5, c6, c8, c9, c11):
+        if self.fold:
+            # latent is the RAW [1,32] flow-decoder output
+            x32 = latent * self.emb_std + self.emb_mean       # [1,32]
+            latent = F.conv1d(x32.unsqueeze(-1), self.proj_w)  # [1,512,1]
+        x, up_p_n = self._upsample(latent, up_p)              # [1,512,16]
+        h = x.transpose(1, 2)                                 # [1,16,512]
+        h, kv0_n = self._tlayer(0, h, kv0, offset)
+        h, kv1_n = self._tlayer(1, h, kv1, offset)
+        z = h.transpose(1, 2)
+
+        z, c0_n = sconv(self.m[0].conv, z, c0)
+        z = elu(z); z, c2_n = sconvtr(self.m[2].convtr, z, c2)
+        z, c3_n = self._resnet(self.m[3], z, c3)
+        z = elu(z); z, c5_n = sconvtr(self.m[5].convtr, z, c5)
+        z, c6_n = self._resnet(self.m[6], z, c6)
+        z = elu(z); z, c8_n = sconvtr(self.m[8].convtr, z, c8)
+        z, c9_n = self._resnet(self.m[9], z, c9)
+        z = elu(z); z, c11_n = sconv(self.m[11].conv, z, c11)
+        if self.graph_state:
+            # commit every state in place AFTER all reads; nothing is returned
+            # but the PCM. `offset` is read only by RoPE/the ring mask above.
+            up_p.copy_(up_p_n); kv0.copy_(kv0_n); kv1.copy_(kv1_n)
+            c0.copy_(c0_n); c2.copy_(c2_n); c3.copy_(c3_n); c5.copy_(c5_n)
+            c6.copy_(c6_n); c8.copy_(c8_n); c9.copy_(c9_n); c11.copy_(c11_n)
+            offset.copy_(offset + STEPS)
+            return z
+        return (z, up_p_n, kv0_n, kv1_n, offset + STEPS,
+                c0_n, c2_n, c3_n, c5_n, c6_n, c8_n, c9_n, c11_n)
+
+
+STATE_NAMES = ("up_p", "kv0", "kv1", "offset", "c0", "c2", "c3", "c5", "c6", "c8", "c9", "c11")
+IN_NAMES = ("latent",) + STATE_NAMES
+OUT_NAMES = ("pcm",) + tuple(f"{n}_out" for n in STATE_NAMES)
+
+
+def init_state(dtype):
+    z = lambda *s: torch.zeros(*s, dtype=dtype)
+    return dict(up_p=z(1, 512, 16), kv0=z(2, 1, RING, 8, 64), kv1=z(2, 1, RING, 8, 64),
+                offset=torch.zeros(1, dtype=torch.int32),
+                c0=z(1, 512, 6), c2=z(1, 256, 6), c3=z(1, 256, 2), c5=z(1, 128, 5),
+                c6=z(1, 128, 2), c8=z(1, 64, 4), c9=z(1, 64, 2), c11=z(1, 64, 2))
+
+
+# ------------------------------------------------------------------------- main
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--oracle", default="oracle/orc_a.npz")
+    ap.add_argument("--dtype", choices=["float32", "float16"], default="float32")
+    ap.add_argument("--artifacts", default="artifacts")
+    ap.add_argument("--skip-export", action="store_true")
+    ap.add_argument("--upsample", choices=["convtr", "outer"], default="convtr")
+    ap.add_argument("--fold-quantizer", action="store_true",
+                    help="graph input is the raw [1,32] latent; rescale+quantizer in-graph")
+    ap.add_argument("--graph-state", action="store_true",
+                    help="the 12 streaming-state tensors become in-graph Core AI state")
+    args = ap.parse_args()
+
+    from pocket_tts import TTSModel
+    torch.set_num_threads(1)
+    orc = np.load(ROOT / args.oracle)
+    gold = torch.from_numpy(orc["mimi/out"])                  # [N,1920]
+    n = gold.shape[0]
+
+    model = TTSModel.load_model().eval()
+    fold_front = None
+    if args.fold_quantizer:
+        proj = model.mimi.quantizer.output_proj
+        assert proj.bias is None, "fold assumes the bias-free output_proj"
+        fold_front = dict(
+            emb_std=model.flow_lm.emb_std.to(torch.float32),
+            emb_mean=model.flow_lm.emb_mean.to(torch.float32),
+            proj_w=proj.weight.to(torch.float32),
+        )
+        # the raw flow-decoder latents, [n,32] so lat[i:i+1] is the [1,32] graph
+        # input; the mimi frames used latents 0..n-1 (the breaking step's latent
+        # is discarded upstream, hence 32 steps -> 31 frames)
+        lat = torch.from_numpy(orc["step/latent"][:n])
+        # sanity: the folded front end must reproduce the captured post-quantizer input
+        with torch.no_grad():
+            q = F.conv1d((lat * fold_front["emb_std"] + fold_front["emb_mean"])
+                         .reshape(n, 32, 1), fold_front["proj_w"])
+        dq = (q.reshape(n, 512) - torch.from_numpy(orc["mimi/in"])).abs().max()
+        assert dq < 1e-5, f"folded front end diverges from oracle mimi/in: {dq}"
+        print(f"[fold] rescale+quantizer front end vs oracle mimi/in: max|Δ| {dq:.2e}")
+    else:
+        lat = torch.from_numpy(orc["mimi/in"]).unsqueeze(-1)  # [N,512,1]
+
+    step = MimiDecoderStep(model.mimi, args.upsample,
+                           fold_front=fold_front, graph_state=args.graph_state).eval()
+
+    def eager_replay():
+        st = init_state(torch.float32)
+        outs = []
+        for i in range(n):
+            if args.graph_state:  # states mutate in place, only pcm returns
+                outs.append(step(lat[i:i + 1], *[st[k] for k in STATE_NAMES]).reshape(-1))
+            else:
+                r = step(lat[i:i + 1], *[st[k] for k in STATE_NAMES])
+                outs.append(r[0].reshape(-1))
+                st = dict(zip(STATE_NAMES, r[1:]))
+        return torch.stack(outs)
+
+    # ---- 1. eager gate ---------------------------------------------------
+    with torch.no_grad():
+        eager = eager_replay()
+    cos = F.cosine_similarity(eager, gold, dim=-1)
+    print(f"[eager fp32] frames {n}  cos mean {cos.mean():.6f} min {cos.min():.6f}  "
+          f"max|Δ| {(eager - gold).abs().max():.3e}")
+    if cos.min() < 0.9999:
+        print("❌ functional re-author DIVERGES — fix before export"); raise SystemExit(1)
+    print("✅ eager functional rewrite reproduces the streaming decoder")
+    if args.skip_export:
+        return
+
+    # ---- 2. export -------------------------------------------------------
+    import asyncio
+    import coreai.runtime as rt
+    from coreai_models.export.macos import export_to_coreai
+
+    dtype = torch.float16 if args.dtype == "float16" else torch.float32
+    st0 = init_state(dtype)
+    lat_example = (torch.zeros(1, 32, dtype=dtype) if args.fold_quantizer
+                   else torch.zeros(1, 512, 1, dtype=dtype))
+    example = {"latent": lat_example, **st0}
+    if args.graph_state:
+        in_names, out_names, state_names = ("latent",), ("pcm",), STATE_NAMES
+    else:
+        in_names, out_names, state_names = IN_NAMES, OUT_NAMES, None
+    tag = ("_q" if args.fold_quantizer else "") + ("_gs" if args.graph_state else "")
+    print(f"[export] mimi decoder ({args.dtype}, ring {RING}, "
+          f"fold={args.fold_quantizer}, graph_state={args.graph_state}) -> Core AI ...",
+          flush=True)
+    prog = export_to_coreai(step.to(dtype), example, dynamic_shapes=None,
+                            input_names=in_names, output_names=out_names,
+                            state_names=state_names, externalize_modules=[])
+    prog.optimize()
+    art = ROOT / args.artifacts; art.mkdir(exist_ok=True)
+    path = art / f"mimi_decoder_{args.dtype}_ring{RING}_{args.upsample}{tag}.aimodel"
+    shutil.rmtree(path, ignore_errors=True)
+    meta = rt.AIModelAssetMetadata(); meta.license = "cc-by-4.0"
+    prog.save_asset(path, meta)
+    sz = sum(f.stat().st_size for f in path.rglob("*") if f.is_file()) / 1e6
+    print(f"[save] {path.name} ({sz:.1f} MB)")
+
+    async def gate(unit):
+        opts = (rt.SpecializationOptions.cpu_only() if unit == "cpu"
+                else rt.SpecializationOptions.from_preferred_compute_unit_kind(
+                    getattr(rt.ComputeUnitKind, unit)()))
+        m = await rt.AIModel.load(str(path), opts)
+        fn = m.load_function("main")
+        outs = []
+        if args.graph_state:
+            state = {k: rt.NDArray(np.ascontiguousarray(v.numpy()))
+                     for k, v in init_state(dtype).items()}
+            for i in range(n):
+                r = await fn(
+                    inputs={"latent": rt.NDArray(np.ascontiguousarray(lat[i:i + 1].to(dtype).numpy()))},
+                    state=state,
+                )
+                outs.append(torch.from_numpy(r["pcm"].numpy().astype(np.float32)).reshape(-1))
+        else:
+            st = {k: v.numpy() for k, v in init_state(dtype).items()}
+            for i in range(n):
+                feed = {"latent": rt.NDArray(np.ascontiguousarray(lat[i:i + 1].to(dtype).numpy()))}
+                feed.update({k: rt.NDArray(v) for k, v in st.items()})
+                r = await fn(feed)
+                outs.append(torch.from_numpy(r["pcm"].numpy().astype(np.float32)).reshape(-1))
+                st = {k: r[f"{k}_out"].numpy() for k in STATE_NAMES}
+        eng = torch.stack(outs)
+        c = F.cosine_similarity(eng, gold, dim=-1)
+        ok = c.mean() > 0.999 and c.min() > 0.99
+        print(f"[gate {unit}] frames {n} cos mean {c.mean():.6f} min {c.min():.6f} "
+              f"max|Δ| {(eng - gold).abs().max():.4f} -> {'PASS' if ok else 'FAIL'}")
+        return ok
+
+    for unit in ("cpu", "gpu"):
+        asyncio.run(gate(unit))
+
+
+if __name__ == "__main__":
+    main()

--- a/conversion/pocket-tts/flowlm_graphs.py
+++ b/conversion/pocket-tts/flowlm_graphs.py
@@ -1,0 +1,280 @@
+"""Static-shape, in-graph-state rewrites of the pocket-tts flow-LM (graphs b/c) and
+the flow decoder (graph d).
+
+Phase A left three export blockers in the flow-LM; all three are answered here:
+
+  * `.item()`-driven KV slice (`modules/transformer.py:14-18`)
+        -> a Core AI **state** (`k_cache` / `v_cache`, mutated in graph) written with
+           `mutable_slice_update` at a runtime `pos` tensor. No Python int, no
+           host round-trip. The whole cache is read back and masked causally, which
+           is exactly upstream's `valid = cache[:, :, : offset + T]` semantics
+           because a position past `pos + T - 1` is never <= any query position.
+  * RNG inside forward (`models/flow_lm.py:131-137`)
+        -> noise is an input to the flow decoder graph; the flow-LM step graph does
+           not draw at all (it stops at `cond` / `eos_logit`).
+  * NaN-as-BOS (`models/tts_model.py:748` -> `models/flow_lm.py:121`)
+        -> deleted. An explicit `is_bos` float flag blends `bos_emb` in.
+
+The KV cache is packed layer-first (`[L, 1, H, S, D]`, already in attention layout)
+so the whole 6-layer cache is TWO states rather than twelve tensors. FluidAudio's
+rank-4 split was a Core ML ANE compiler constraint; the Core AI zoo ships rank-5
+packed caches (vibevoice / dots_tts) and they specialize fine, so the split buys
+nothing here.
+
+Parity traps honoured (NOTES.md section 7): interleaved-pair RoPE with an absolute
+offset, LayerNorm eps 1e-5 in the transformer / 1e-6 in the flow net, the flow net's
+non-standard `RMSNorm` (mean-centred, *unbiased* variance, eps outside the rsqrt),
+`bos -> voice -> text -> latents` ordering, and the fact that the cache holds
+POST-RoPE keys.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+
+import torch
+import torch.nn as nn
+from torch.nn import functional as F
+
+from coreai_models.primitives._ops import mutable_slice_update
+
+# --- static graph budget -----------------------------------------------------
+# The cache must hold: voice conditioning + the text chunk + EVERY generated frame,
+# because the flow-LM has no context window and so nothing ever rolls out of it.
+#
+#   voice conditioning   76..162 positions — it is NOT 126 for every voice. The eight
+#                        shipped English voices measure 126/126/126/126/133/141/162,
+#                        and the wider v3 catalogue runs 76..162.
+#   text chunk           <= MAX_TOKEN_PER_CHUNK = 50 (upstream's chunker can still
+#                        emit more when a long sentence has no comma/colon to split
+#                        on — measured at 121 tokens on one Moby Dick sentence).
+#   generation           bounded by upstream's own `_estimate_max_gen_len`, which is
+#                        ceil((tokens/3 + 2) * 12.5) = 234 frames for a 50-token chunk.
+#
+# Worst legal case is therefore 162 + 50 + 234 = 446, so **S_MAX = 512**. The Phase B
+# value of 256 was sized off the oracle fixture's 32 generated frames and truncates any
+# chunk over roughly 35 tokens; see NOTES.md section 16.
+S_MAX = int(os.environ.get("POCKET_TTS_S_MAX", "512"))
+T_PRE = 16          # prefill chunk width (pad the text chunk up to this)
+N_LAYERS = 6
+N_HEADS = 16
+HEAD_DIM = 64
+D_MODEL = 1024
+LDIM = 32
+
+STATE_NAMES = ("k_cache", "v_cache")
+
+
+def build_kv_state(dtype=torch.float32) -> dict[str, torch.Tensor]:
+    """Zero-initialised, NOT NaN-initialised — a masked SDPA still multiplies V by a
+    zero weight and 0 * NaN = NaN (NOTES.md section 6, blocker iii-b)."""
+    shape = (N_LAYERS, 1, N_HEADS, S_MAX, HEAD_DIM)
+    return {
+        "k_cache": torch.zeros(shape, dtype=dtype),
+        "v_cache": torch.zeros(shape, dtype=dtype),
+    }
+
+
+def _write_kv(cache: torch.Tensor, layer: int, pos: torch.Tensor, x: torch.Tensor) -> None:
+    """cache[layer, :, :, pos : pos + T] = x, with `pos` a runtime i32 tensor.
+
+    x is [1, H, T, D]. `mutable_slice_update` is the zoo's data-indexed state write;
+    it survives `remove_functionalization` and lowers to an in-place state mutation.
+    """
+    dev = cache.device
+    t = x.shape[2]
+    li = torch.tensor([layer], dtype=torch.int32, device=dev)
+    z = torch.zeros(1, dtype=torch.int32, device=dev)
+    one = torch.ones(1, dtype=torch.int32, device=dev)
+    nh = torch.tensor([cache.shape[2]], dtype=torch.int32, device=dev)
+    hd = torch.tensor([cache.shape[4]], dtype=torch.int32, device=dev)
+    tn = torch.tensor([t], dtype=torch.int32, device=dev)
+    p = pos.reshape(1).to(torch.int32)
+    begin = torch.cat([li, z, z, p, z])
+    end = torch.cat([li + 1, one, nh, p + tn, hd])
+    mutable_slice_update(cache, x.unsqueeze(0), begin, end)
+
+
+def _rope(q: torch.Tensor, k: torch.Tensor, pos: torch.Tensor, max_period: float = 10_000.0):
+    """Interleaved-pair (complex) RoPE — `modules/rope.py:36-56`, verbatim except that
+    the offset is a runtime tensor instead of a Python int. Rotation math in fp32."""
+    b, t, h, d = q.shape
+    ds = torch.arange(d // 2, device=q.device, dtype=torch.float32)
+    freqs = torch.exp(ds * (-math.log(max_period) * 2 / d))
+    # pos stays rank-1: `coreai.reshape` rejects a rank-0 shape operand, so a
+    # `.reshape(())` scalar squeeze does not lower. Broadcasting [T] + [1] is fine.
+    ts = (torch.arange(t, device=q.device, dtype=torch.float32) + pos.to(torch.float32)).view(
+        -1, 1, 1
+    )
+    q = q.view(b, t, h, d // 2, 2)
+    k = k.view(b, t, h, d // 2, 2)
+    qr, qi = q[..., 0].float(), q[..., 1].float()
+    kr, ki = k[..., 0].float(), k[..., 1].float()
+    rotr, roti = torch.cos(freqs * ts), torch.sin(freqs * ts)
+    # rotation math in fp32, cast back to the working precision (upstream `rope.py:54`)
+    dt = q.dtype
+    qo = torch.stack([qr * rotr - qi * roti, qr * roti + qi * rotr], dim=-1).to(dt)
+    ko = torch.stack([kr * rotr - ki * roti, kr * roti + ki * rotr], dim=-1).to(dt)
+    return qo.view(b, t, h, d), ko.view(b, t, h, d)
+
+
+class FlowLMCore(nn.Module):
+    """The 6-layer flow-LM backbone with a static KV state.
+
+    forward(x [1,T,1024], pos [1] i32, k_cache, v_cache) -> cond [1,T,1024]
+
+    `x` is already `input_linear(sequence)` for AR steps, or the raw text embeddings
+    for prefill — upstream concatenates the two and only ever has one of them
+    non-empty per call (`models/flow_lm.py:150`, `models/tts_model.py:356`).
+    """
+
+    def __init__(self, flow_lm: nn.Module):
+        super().__init__()
+        self.layers = flow_lm.transformer.layers
+        self.out_norm = flow_lm.out_norm
+
+    def forward(self, x, pos, k_cache, v_cache):
+        t = x.shape[1]
+        # causal mask over the whole cache: slot j is visible to query row i iff
+        # j <= pos + i. Slots above that are either unwritten (zero) or this call's
+        # own future rows — exactly upstream's `valid = cache[..., : offset + T]`.
+        k_idx = torch.arange(S_MAX, device=x.device, dtype=torch.float32)
+        q_pos = torch.arange(t, device=x.device, dtype=torch.float32) + pos.to(torch.float32)
+        mask = k_idx.view(1, 1, 1, S_MAX) <= q_pos.view(1, 1, t, 1)
+
+        for i, layer in enumerate(self.layers):
+            h = layer.norm1(x)
+            projected = layer.self_attn.in_proj(h)
+            packed = projected.view(1, t, 3, N_HEADS, HEAD_DIM)
+            q, k, v = torch.unbind(packed, dim=2)
+            q, k = _rope(q, k, pos)
+            q = q.transpose(1, 2)                       # [1,H,T,D]
+            _write_kv(k_cache, i, pos, k.transpose(1, 2))
+            _write_kv(v_cache, i, pos, v.transpose(1, 2))
+            a = F.scaled_dot_product_attention(q, k_cache[i], v_cache[i], mask, dropout_p=0.0)
+            a = a.transpose(1, 2).reshape(1, t, D_MODEL)
+            x = x + layer.self_attn.out_proj(a)
+            # FFN (`modules/mimi_transformer.py:_ff_block`) — no layer scale on the flow-LM
+            x = x + layer.linear2(F.gelu(layer.linear1(layer.norm2(x))))
+        return self.out_norm(x)
+
+
+class FlowLMStep(nn.Module):
+    """Graph (c) — one AR step.
+
+    latent_in [1,1,32], is_bos [1], pos [1] i32, + KV state
+        -> cond [1,1024], eos_logit [1,1]
+    """
+
+    def __init__(self, flow_lm: nn.Module):
+        super().__init__()
+        self.core = FlowLMCore(flow_lm)
+        self.input_linear = flow_lm.input_linear
+        self.out_eos = flow_lm.out_eos
+        self.register_buffer("bos_emb", flow_lm.bos_emb.detach().clone())
+
+    def forward(self, latent_in, is_bos, pos, k_cache, v_cache):
+        f = is_bos.reshape(1, 1, 1)
+        seq = f * self.bos_emb.view(1, 1, LDIM) + (1.0 - f) * latent_in
+        x = self.input_linear(seq)
+        cond = self.core(x, pos, k_cache, v_cache)[:, -1]
+        return cond, self.out_eos(cond)
+
+
+class FlowLMPrefill(nn.Module):
+    """Graph (b) — one T_PRE-wide text chunk into the same KV state.
+
+    text_emb [1,T_PRE,1024], pos [1] i32, + KV state -> cond [1,1024]
+
+    The output is discarded by the host (upstream's prefill call emits a latent it
+    throws away — `models/flow_lm.py:156` with `sequence.shape[1] == 0` keeps the
+    whole tensor because `-0 == 0`; see NOTES.md section 7). Short chunks are padded to
+    T_PRE: the pad rows write junk into cache slots that no real row can attend to
+    (they sit strictly after every real position) and that the first AR steps
+    overwrite before ever reading them.
+    """
+
+    def __init__(self, flow_lm: nn.Module):
+        super().__init__()
+        self.core = FlowLMCore(flow_lm)
+
+    def forward(self, text_emb, pos, k_cache, v_cache):
+        return self.core(text_emb, pos, k_cache, v_cache)[:, -1]
+
+
+class _VarFreeRMSNorm(nn.Module):
+    """`modules/mlp.py:20-36` without `torch.var`.
+
+    `aten.var.correction` has no Core AI lowering on coreai-torch 0.4.1 (same class of
+    gap as the `aten.elu` one Phase A hit in SEANet). The flow net's `RMSNorm` is not
+    RMSNorm: it mean-CENTRES, uses the UNBIASED (n-1) estimator, and adds eps OUTSIDE
+    the rsqrt. All three are reproduced literally here.
+    """
+
+    def __init__(self, src: nn.Module):
+        super().__init__()
+        self.alpha = nn.Parameter(src.alpha.detach().clone())
+        self.eps = src.eps
+
+    def forward(self, x):
+        n = x.shape[-1]
+        mu = x.mean(dim=-1, keepdim=True)
+        var = ((x - mu) ** 2).sum(dim=-1, keepdim=True) / (n - 1)
+        return x * (self.alpha * torch.rsqrt(self.eps + var))
+
+
+class _VarFreeLayerNorm(nn.Module):
+    """`modules/mlp.py:39-55` without `torch.var` — biased (n) estimator, eps 1e-6
+    INSIDE the sqrt, affine optional (`FinalLayer.norm_final` has none)."""
+
+    def __init__(self, src: nn.Module):
+        super().__init__()
+        self.eps = src.eps
+        self.affine = hasattr(src, "weight")
+        if self.affine:
+            self.weight = nn.Parameter(src.weight.detach().clone())
+            self.bias = nn.Parameter(src.bias.detach().clone())
+
+    def forward(self, x):
+        mu = x.mean(dim=-1, keepdim=True)
+        var = ((x - mu) ** 2).mean(dim=-1, keepdim=True)
+        x = (x - mu) / torch.sqrt(var + self.eps)
+        return x * self.weight + self.bias if self.affine else x
+
+
+def _replace_var_norms(module: nn.Module) -> nn.Module:
+    from pocket_tts.modules.mlp import LayerNorm as PtLayerNorm, RMSNorm as PtRMSNorm
+
+    for name, child in module.named_children():
+        if isinstance(child, PtRMSNorm):
+            setattr(module, name, _VarFreeRMSNorm(child))
+        elif isinstance(child, PtLayerNorm):
+            setattr(module, name, _VarFreeLayerNorm(child))
+        else:
+            _replace_var_norms(child)
+    return module
+
+
+class FlowDecoder(nn.Module):
+    """Graph (d) — the LSD flow decoder at num_steps=1 (upstream's default,
+    `pocket_tts/default_parameters.py:3`).
+
+    cond [1,1024], noise [1,32] -> latent [1,32]
+
+    At num_steps=1 `lsd_decode` is `x0 + v(s=0, t=1, x0)`, so `s`/`t` are baked as
+    zeros/ones constants. The in-place `current += flow_dir / num_steps` of
+    `models/flow_lm.py:38` is written out-of-place here — that mutation is the trap
+    that forced the oracle to clone `step/noise` at capture time.
+    """
+
+    def __init__(self, flow_lm: nn.Module):
+        super().__init__()
+        import copy
+
+        self.flow_net = _replace_var_norms(copy.deepcopy(flow_lm.flow_net))
+
+    def forward(self, cond, noise):
+        s = torch.zeros_like(noise[..., :1])
+        t = torch.ones_like(noise[..., :1])
+        return noise + self.flow_net(cond, s, t, noise)

--- a/conversion/pocket-tts/gen_oracle.py
+++ b/conversion/pocket-tts/gen_oracle.py
@@ -1,0 +1,185 @@
+"""PyTorch reference ("oracle") run for the pocket-tts Core AI port.
+
+Runs upstream inference on a fixed prompt/voice and captures every tensor a later
+Core AI graph must reproduce. Two RNG modes:
+
+  --rng explicit  (default)  noise drawn from a dedicated torch.Generator, one draw
+                             per flow-LM call, seeded seed+call_index. Deterministic
+                             by construction and independent of thread scheduling.
+  --rng stock                upstream path (global RNG via torch.nn.init.normal_),
+                             seeded with torch.manual_seed. Used to test whether the
+                             stock path reproduces at all.
+
+Writes: oracle/<tag>.npz, oracle/<tag>.wav, oracle/<tag>.json
+"""
+
+import argparse, hashlib, json, platform, sys, time
+from functools import partial
+from pathlib import Path
+
+import numpy as np
+import scipy.io.wavfile
+import torch
+
+from pocket_tts import TTSModel
+from pocket_tts.conditioners.base import TokenizedText
+from pocket_tts.models.flow_lm import FlowLMModel, lsd_decode
+from pocket_tts.models.mimi import MimiModel
+
+torch.set_num_threads(1)
+
+ROOT = Path(__file__).resolve().parent.parent
+ORACLE = ROOT / "oracle"
+
+PROMPT = "The quick brown fox jumps over the lazy dog."
+VOICE = "alba"
+
+
+class Capture:
+    def __init__(self, seed: int, mode: str):
+        self.seed = seed
+        self.mode = mode
+        self.calls = 0            # flow-LM forward calls (prefill counts as call 0)
+        self.rec = {}             # name -> list of arrays
+        self.gen = torch.Generator(device="cpu")
+
+    def add(self, key, t):
+        self.rec.setdefault(key, []).append(
+            t.detach().to(torch.float32).cpu().numpy().copy()
+        )
+
+
+def instrument(model: TTSModel, cap: Capture):
+    """Replace FlowLMModel.forward with an exact copy that records + injects noise."""
+
+    def flow_forward(self, sequence, text_embeddings, model_state, lsd_decode_steps,
+                     temp, noise_clamp, eos_threshold):
+        idx = cap.calls
+        cap.calls += 1
+        is_prefill = sequence.shape[1] == 0
+
+        cap.add(f"in/seq_len_text_{idx}", torch.tensor([text_embeddings.shape[1]]))
+        if is_prefill:
+            cap.add("prefill/text_embeddings", text_embeddings)
+
+        # --- upstream body, verbatim (models/flow_lm.py forward) ---
+        sequence = torch.where(torch.isnan(sequence), self.bos_emb, sequence)
+        input_ = self.input_linear(sequence)
+        transformer_out = self.backbone(input_, text_embeddings, sequence, model_state=model_state)
+        transformer_out = transformer_out.to(torch.float32)
+        assert lsd_decode_steps > 0
+        transformer_out = transformer_out[:, -1]
+        eos_logit = self.out_eos(transformer_out)
+        out_eos = eos_logit > eos_threshold
+
+        noise_shape = transformer_out.shape[:-1] + (self.ldim,)
+        std = temp ** 0.5
+        noise = torch.empty(noise_shape, dtype=transformer_out.dtype, device=transformer_out.device)
+        if cap.mode == "explicit":
+            cap.gen.manual_seed(cap.seed + idx)
+            if noise_clamp is None:
+                noise.normal_(mean=0.0, std=std, generator=cap.gen)
+            else:
+                torch.nn.init.trunc_normal_(noise, mean=0.0, std=std, a=-noise_clamp, b=noise_clamp)
+        else:
+            if noise_clamp is None:
+                torch.nn.init.normal_(noise, mean=0.0, std=std)
+            else:
+                torch.nn.init.trunc_normal_(noise, mean=0.0, std=std, a=-noise_clamp, b=noise_clamp)
+
+        if not is_prefill:
+            cap.add("step/cond", transformer_out)       # [1,1024] flow-LM hidden, post out_norm
+            cap.add("step/eos_logit", eos_logit)        # [1,1]
+            cap.add("step/noise", noise)                # [1,32] BEFORE lsd_decode mutates it
+
+        conditioned_flow = partial(self.flow_net, transformer_out)
+        latent = lsd_decode(conditioned_flow, noise, lsd_decode_steps)
+        if not is_prefill:
+            cap.add("step/latent", latent)              # [1,32]
+        return latent, out_eos
+
+    FlowLMModel.forward = flow_forward
+
+    orig_decode = MimiModel.decode_from_latent
+
+    def mimi_decode(self, latent, mimi_state):
+        cap.add("mimi/in", latent)                      # [1,512,1] post-quantizer
+        out = orig_decode(self, latent, mimi_state)
+        cap.add("mimi/out", out)                        # [1,1,1920]
+        return out
+
+    MimiModel.decode_from_latent = mimi_decode
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--rng", choices=["explicit", "stock"], default="explicit")
+    ap.add_argument("--seed", type=int, default=1234)
+    ap.add_argument("--tag", default=None)
+    ap.add_argument("--text", default=PROMPT)
+    ap.add_argument("--voice", default=VOICE)
+    args = ap.parse_args()
+    tag = args.tag or f"oracle_{args.rng}_s{args.seed}"
+    ORACLE.mkdir(exist_ok=True)
+
+    model = TTSModel.load_model()
+    model.eval()
+    cap = Capture(args.seed, args.rng)
+    instrument(model, cap)
+
+    voice_state = model.get_state_for_audio_prompt(args.voice)
+    # voice conditioning state, as shipped (the no-cloning checkpoint ships it pre-baked)
+    for mod_name, st in voice_state.items():
+        for k, v in st.items():
+            cap.add(f"voice/{mod_name}/{k}", v)
+
+    tok = model.flow_lm.conditioner.prepare(args.text)
+    cap.add("prefill/text_tokens", tok.tokens)
+
+    torch.manual_seed(args.seed)
+    t0 = time.monotonic()
+    audio = model.generate_audio(voice_state, args.text, copy_state=True)
+    wall = time.monotonic() - t0
+
+    wav = audio.numpy().astype(np.float32)
+    scipy.io.wavfile.write(ORACLE / f"{tag}.wav", model.sample_rate, wav)
+
+    out = {}
+    for key, lst in cap.rec.items():
+        if key.startswith(("step/", "mimi/")):
+            out[key] = np.concatenate([a.reshape(1, -1) for a in lst], axis=0)
+        else:
+            out[key] = lst[0] if len(lst) == 1 else np.stack(lst)
+    out["wav"] = wav
+    np.savez(ORACLE / f"{tag}.npz", **out)
+
+    digest = {k: hashlib.sha256(np.ascontiguousarray(v).tobytes()).hexdigest()[:16]
+              for k, v in sorted(out.items())}
+    meta = dict(
+        tag=tag, rng=args.rng, seed=args.seed, text=args.text, voice=args.voice,
+        n_flowlm_calls=cap.calls, n_steps=out["step/latent"].shape[0],
+        n_mimi_frames=out["mimi/out"].shape[0],
+        wav_samples=int(wav.shape[0]), sample_rate=int(model.sample_rate),
+        duration_s=round(wav.shape[0] / model.sample_rate, 4), wall_s=round(wall, 3),
+        temp=model.temp, lsd_decode_steps=model.lsd_decode_steps,
+        noise_clamp=model.noise_clamp, eos_threshold=model.eos_threshold,
+        frames_after_eos=model.model_recommended_frames_after_eos,
+        shapes={k: list(v.shape) for k, v in sorted(out.items())},
+        sha256_16=digest,
+        versions=dict(
+            python=sys.version.split()[0], torch=torch.__version__,
+            numpy=np.__version__, platform=platform.platform(),
+            pocket_tts=__import__("importlib.metadata", fromlist=["version"]).version("pocket-tts"),
+        ),
+    )
+    (ORACLE / f"{tag}.json").write_text(json.dumps(meta, indent=2))
+    print(json.dumps({k: meta[k] for k in
+                      ("tag","rng","seed","n_flowlm_calls","n_steps","n_mimi_frames",
+                       "duration_s","wall_s")}, indent=2))
+    print("shapes:")
+    for k, v in sorted(meta["shapes"].items()):
+        print(f"  {k:34s} {v}")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/pocket-tts/README.md
+++ b/models/pocket-tts/README.md
@@ -1,0 +1,162 @@
+# pocket-tts (Kyutai) on Core AI
+
+Text to speech from [`kyutai/pocket-tts-without-voice-cloning`](https://huggingface.co/kyutai/pocket-tts-without-voice-cloning)
+(CC-BY-4.0), running end to end on Core AI with a native Swift host:
+[pocket-tts-swift](https://github.com/RahulRachuri/pocket-tts-swift). The model is an
+autoregressive flow-matching LM over Mimi audio latents at 12.5 Hz, a one-step flow
+decoder, and a streaming Mimi decoder to 24 kHz PCM. Eight shipped voices via
+conditioning embeddings from [kyutai/tts-voices](https://huggingface.co/kyutai/tts-voices).
+
+The GAP/EDGE sentence: Apple's stock stack has no natural multi-voice neural TTS of this
+class, MLX runs this model faster on a Mac (10.5x against this port's 8.5x) but has no
+iPhone path, so this port's case is the phone, where the fully gated pipeline holds
+7.8x real time in a 169 MB peak footprint from a native Swift host.
+
+## Pipeline
+
+```
+text ──(host: native sentencepiece + chunker, hard cap voice_pos+n_text+max_gen_len<=512)──▶ token ids
+  1. flowlm_*.aimodel      two functions over one shared rank-5 KV state (S_MAX=512, derived):
+       prefill(text_emb[1,16,1024], pos[1] i32) -> cond[1,1024]        windowed, pos carried
+       step(latent_in[1,1,32], is_bos[1], pos[1] i32) -> cond, eos_logit
+  2. flow_decoder_*.aimodel  flow(cond[1,1024], noise[1,32]) -> latent[1,32]   one-step (lsd1), stateless
+     host: EOS compare (logit > -4.0), seeded torch-exact noise, AR loop
+  3. mimi_decoder_*_q_gs.aimodel  latent[1,32] -> pcm[1,1,1920]
+     rescale + k=1 quantizer folded in-graph; 12 streaming-state tensors held as
+     in-graph Core AI state, never reset across chunks (structural, not conventional)
+audio: chunks concatenated directly, no crossfade (gated: max join step 0.0246 vs in-audio p99.9 0.1878)
+```
+
+The KV cache has no context window, so capacity is derived from the model's own bound:
+worst legal chunk is 162 voice + 50 text + 234 generated frames = 446, so S_MAX = 512.
+Upstream's chunker overshoots its own 50-token cap (observed max 121 tokens), so the
+Swift host enforces the cap by whitespace-splitting the remainder, plus a runtime
+precondition in the AR loop. This checkpoint generates 2.47 frames per text token on
+average, which is why a fixture-sized S_MAX = 256 silently truncated real sentences and
+only an end-to-end sweep could see it.
+
+## Gates
+
+Per-graph, teacher-forced on the oracle's own latents (fp32, S=512 assets):
+
+| gate | cpu_only | gpu |
+|---|---|---|
+| flow-LM step + prefill | cos 1.000000, max abs 3.0e-6, 0 EOS flips | cos 1.000000, 3.9e-6, 0 flips |
+| flow decoder | cos 1.000000, max abs 3.34e-6 | cos 1.000000, 1.43e-6 |
+| Mimi decoder (`_q_gs`) | cos 1.000000, max abs 0.0 (bit-identical) | cos 1.000000, 0.0 |
+
+End to end, free-running, oracle seed and noise protocol: framing identical to the
+PyTorch oracle (14 tokens to 32 steps, EOS at step 28, 31 frames), wav cos 1.000000,
+max abs 1e-4. ASR round trip through the sibling parakeet-swift port: 0.00 % WER on the
+oracle prompt, 1.38 % (2/145) on a 148-word paragraph.
+
+Corpus sweep, 302 sentences across all eight voices: 4.27 % WER, 0 capped chunks, 0
+missing EOS, 0 clipped clips. The short-utterance tail (1 to 6 words, about 19 % WER) is
+upstream's, reproduced at the same rate by pure PyTorch (19.0 % port against 20.0 %
+upstream, seed-matched); on matched rows longer than 6 words the two are 2.22 % against
+1.89 %. Ten-minute long-form run (2183 words, 97 chunks): 2.53 % WER, drift flat
+(+0.09 pp per decile against 4.7 pp decile spread), all 96 stitch points below the
+in-audio p99.9 step, no crossfade needed.
+
+Device transfer (iPhone 17 Pro Max, A19 Pro, iOS 27.0, Release): under `cpuOnly` all 8
+per-graph probe dumps are bit-identical to the M4 Pro, including post-run KV and Mimi
+state. On gpu the oracle-prompt wav scores cos 1.000000, max abs 4.3e-5, and the ASR
+numbers reproduce the Mac's exactly (0.00 % and 1.38 %). fp16 does not transfer bit-wise
+across chips (A19 Pro against M4 Pro), and gpu fp32 is not bit-transferable across GPU
+architectures either; the strict transfer property belongs to `cpuOnly`, and gpu
+correctness is carried by the oracle-prompt cosine, the framing, and the ASR gate.
+
+## Speed
+
+Mac, M4 Pro, 148-word paragraph, voice alba, load excluded, 1 warmup + 3 timed, medians.
+The quiet-machine ladder (M1-era assets, fresh subprocess per run):
+
+| stack | RTF | x realtime |
+|---|---:|---:|
+| upstream PyTorch (mps) | 0.2027 | 4.9x |
+| this port, fp32 (gpu) | 0.1663 | 6.0x |
+| this port, fp16 (gpu) | 0.1562 | 6.4x |
+| pocket-tts-mlx 0.2.1 (metal) | 0.0953 | 10.5x |
+
+The published M2 assets (in-graph Mimi state) on the same protocol, ambient machine:
+fp32 0.1281 (7.8x), fp16 0.1171 (8.5x). The fp16 gap to MLX is 1.23x, and 58 % of the
+remaining wall is the flow-LM step graph itself. Honest framing: faster than upstream
+PyTorch on the same Mac, behind Metal-native MLX; the case for this port is the phone
+and the Swift host, not Mac headline speed.
+
+Device, iPhone 17 Pro Max (A19 Pro), iOS 27.0, Release build, JIT `.aimodel`, charging,
+thermal nominal before and after every run, same paragraph and protocol:
+
+| config | RTF median | x realtime | peak RSS | load |
+|---|---:|---:|---:|---:|
+| fp32 gpu | 0.1646 | 6.1x | 202 MB | 0.7 s |
+| fp16 gpu | 0.1281 | 7.8x | 169 MB | 0.4 s |
+| fp32 cpuOnly (spot check) | 0.5324 | 1.9x | 225 MB | 0.02 s |
+
+gpu is 3.2x faster than cpuOnly on device, measured rather than assumed from the Mac.
+Warmup (first-call specialization) is about 0.3 s on device against about 4.5 s on the
+Mac. fp16 keeps the fp32 Mimi decoder throughout; the flow-LM and flow decoder carry the
+precision split.
+
+For a same-device comparison, FluidInference's `pocket-tts-coreml` was run through their
+own FluidAudio SDK (0.15.5) on the same phone with default settings (their real shipping
+configuration: fp16, gpu placement, Mimi pinned to cpuOnly by their loader) on a matched
+~150-word passage through their whole-utterance API. Their route measures RTF 0.399
+(2.51x realtime, median of 3); this port's fp16 path is about 3.1x faster on the same
+hardware. Two protocol notes for fairness: the passage is matched in length but not
+byte-identical to the paragraph above, and their internal chunking runs inside the single
+timed call. MLX is not a comparator on iOS: no MLX-Swift port of pocket-tts exists, so
+Core ML and Core AI are the only phone routes for this model today.
+
+## The port in five Core AI bugs
+
+All five are verified with minimal repros and drafted as Feedback Assistant reports, held
+by the contributor pending filing. Repros are available on request.
+
+1. **ConvTranspose1d is numerically wrong on the `cpu_only` delegate** at stride >= 8
+   and kernel >= 16 (the same asset is correct on gpu). Mimi's k=32/s=16/groups=512
+   upsample hit it at cos -0.01. Workaround: at T=1 with groups == channels the op
+   degenerates to a per-channel outer product, and re-authoring it that way takes
+   `cpu_only` to bit-exact.
+2. **The Python `coreai.runtime` bindings leak one IOSurface per call.** With this
+   pipeline's state sizes the process dies at about 2,250 calls, climbing 1.9 MB per
+   call to about 3 GB. Every Python harness runs generation in subprocess workers on a
+   1,500-call budget. The Swift `CoreAI` framework does not leak: one process ran 4,773
+   calls flat at 300 MB.
+3. **coreai-torch lowers ConvTranspose `output_padding` by padding the input**, which
+   silently produces the wrong output length. This is a converter defect and goes to the
+   apple/coreai-torch tracker as well as Feedback Assistant. The streaming rewrite here
+   never uses `output_padding`, so the port is unaffected; the repro is in the report.
+4. **fp32 graphs with in-graph state abort the process under the default
+   `SpecializationOptions`** (SIGABRT in ANERegionFormationPass) instead of falling back.
+   Since both main graphs carry in-graph state, every load states an explicit `gpu` or
+   `cpuOnly` preference, and the host refuses the aborting pairs in code rather than by
+   convention. ANE work is parked behind this bug.
+5. **`preferredComputeUnitKind: .cpu` silently returns wrong numerics**; the same asset
+   is correct with `.cpuOnly` and with `.gpu`. Parity work must use `.cpuOnly`, and
+   `.cpu` should not appear in a host at all.
+
+## Bundle
+
+Five `.aimodel` bundles, hosted on the contributor's Hugging Face
+([rahulrachuri/pocket-tts-coreai](https://huggingface.co/rahulrachuri/pocket-tts-coreai)),
+CC-BY-4.0 inherited from the model:
+
+| bundle | size | role |
+|---|---:|---|
+| `flowlm_float32_s512.aimodel` | 302.4 MB | flow-LM prefill + step, parity config |
+| `flowlm_float16_s512.aimodel` | 151.3 MB | flow-LM, device config |
+| `flow_decoder_float32_lsd1.aimodel` | 39.1 MB | one-step flow decoder |
+| `flow_decoder_float16_lsd1.aimodel` | 19.6 MB | flow decoder, device config |
+| `mimi_decoder_float32_ring272_outer_q_gs.aimodel` | 41.3 MB | Mimi decoder, fp32 always |
+
+The host additionally needs Kyutai's own files, fetched from Kyutai's repos and not
+redistributed here: `model.safetensors` (embedding LUT, rescale constants, quantizer),
+`tokenizer.model`, and the per-voice embeddings from
+[kyutai/tts-voices](https://huggingface.co/kyutai/tts-voices).
+
+Convert yourself with [`conversion/pocket-tts/`](../../conversion/pocket-tts/): generate
+the oracle capture first (`gen_oracle.py --tag orc_a`), then run the three exporters per
+`recipe.toml`. Each exporter gates its graph against the oracle (eager, `cpu_only`, and
+`gpu`) before writing the bundle. The full gate ladder, the corpus sweep harness, and
+the device probes live in the host repo.

--- a/models/pocket-tts/recipe.toml
+++ b/models/pocket-tts/recipe.toml
@@ -1,0 +1,26 @@
+# Recipe for pocket-tts: the configuration that produced each published bundle.
+# Schema and the rules for `status`: ../README.md.
+# Run it with:  python3 ../../conversion/zoo_convert.py run <name>
+
+["pocket-tts"]
+card = "README.md"
+hf_repo = "rahulrachuri/pocket-tts-coreai"
+source_hf_id = "kyutai/pocket-tts-without-voice-cloning"
+status = "verified"
+steps = [
+  { script = "pocket-tts/export_mimi_decoder.py", args = ["--upsample", "outer", "--fold-quantizer", "--graph-state"], bundle = "mimi_decoder_float32_ring272_outer_q_gs.aimodel" },
+  { script = "pocket-tts/export_flowlm.py", args = [], bundle = "flowlm_float32_s512.aimodel" },
+  { script = "pocket-tts/export_flowlm.py", args = ["--dtype", "float16"], bundle = "flowlm_float16_s512.aimodel" },
+  { script = "pocket-tts/export_flow_decoder.py", args = [], bundle = "flow_decoder_float32_lsd1.aimodel" },
+  { script = "pocket-tts/export_flow_decoder.py", args = ["--dtype", "float16"], bundle = "flow_decoder_float16_lsd1.aimodel" },
+]
+notes = [
+  "Prerequisite: an oracle capture. Run pocket-tts/gen_oracle.py --tag orc_a first (needs the",
+  "pocket_tts pip package and HF_HOME pointing at a cache holding the Kyutai checkpoint); every",
+  "exporter gates against oracle/orc_a.npz (eager, cpu_only, gpu) before writing its bundle.",
+  "Exports need DEVELOPER_DIR pointing at the Xcode 27 beta. S_MAX = 512 is derived inside",
+  "flowlm_graphs.py from the model's own generation bound (162 voice + 50 text + 234 frames),",
+  "not passed as a flag. The Mimi decoder ships fp32 only; fp16 covers the flow-LM and the",
+  "flow decoder. The Mimi flags fold the rescale + k=1 quantizer in-graph (--fold-quantizer)",
+  "and hold the 12 streaming-state tensors as in-graph Core AI state (--graph-state).",
+]


### PR DESCRIPTION
Port of Kyutai's [pocket-tts](https://huggingface.co/kyutai/pocket-tts-without-voice-cloning) to Core AI, closing #11. The zoo's first Kyutai model, and its first Mimi conversion.

Bundles: [rahulrachuri/pocket-tts-coreai](https://huggingface.co/rahulrachuri/pocket-tts-coreai), revision `ad989309a578`. Swift host: [RahulRachuri/pocket-tts-swift](https://github.com/RahulRachuri/pocket-tts-swift).

## Against the three bars

**Licence.** CC-BY-4.0, inherited from the ungated `pocket-tts-without-voice-cloning` checkpoint at revision `e041936c`, attribution to Kyutai noted on the card. Upstream weights are not mirrored; the host reads Kyutai's own `model.safetensors`, `tokenizer.model` and per-voice embeddings directly.

**Parity.** Per-graph teacher-forced against the fp32 oracle, then free-running end to end. Every graph is cos 1.000000 on both `cpu_only` and `gpu`; the Mimi decoder is bit-identical. End to end the framing matches the PyTorch oracle exactly (14 tokens to 32 steps, EOS at 28, 31 frames) at wav cos 1.000000. Because tensor similarity can pass while audio is unintelligible, there is also an ASR round trip: 0.00% WER on the oracle prompt, 1.38% on a 148-word paragraph, 4.27% across a 302-sentence corpus sweep over all eight voices with zero capped chunks and zero missing EOS, and 2.53% on a ten-minute long-form run.

**Real hardware.** M4 Pro and iPhone 17 Pro Max, Release builds, full tables on the card.

| | RTF | ×realtime |
|---|---:|---:|
| Mac M4 Pro, fp16 | 0.1171 | 8.5× |
| iPhone 17 Pro Max, fp16 | 0.1281 | 7.8× |
| iPhone 17 Pro Max, fp32 | 0.1646 | 6.1× |

Peak RSS on device is 169 MB at fp16, load 0.4 s. Under `cpuOnly` all eight per-graph probe dumps are bit-identical between device and Mac, including post-run KV and Mimi state.

Honest framing, also on the card: MLX is faster on the Mac (10.5× against 8.5×), but has no iPhone path for this model, so the case for this port is the phone. For a same-device comparison, FluidInference's `pocket-tts-coreml` through the FluidAudio SDK at its shipping defaults measures 2.51× on the same handset, so this port's fp16 path is about 3.1× faster there. Two fairness notes travel with that number on the card: the passage is length-matched but not byte-identical, and their internal chunking runs inside the timed call.

## Checks

- `zoo_verify.py rahulrachuri/pocket-tts-coreai` → 5 bundles, PASS 5, DIFF 0, FAIL 0
- `zoo_convert.py show pocket-tts` → prints all five export commands
- Exported with `coreai-core` 1.0.0b2, above the SDK floor

## Notes for review

Two structural choices are worth your eye, since both diverge from how the neighbouring ports do it.

The KV cache has no context window, so `S_MAX` is derived from the model's own generation bound (162 voice + 50 text + 234 generated = 446, rounded to 512) rather than configured. A fixture-sized 256 silently truncated real sentences, and only an end-to-end sweep caught it.

Prefill is a second function over the shared state at a static width of 16 tokens, applied as a sliding window. That is also why the large-prefill SDPA lowering crash from the LFM2-Audio notes never triggered here.

**One finding that may belong in `knowledge/`.** Fixed-capacity KV caches for this family must be zero-initialised, never NaN-initialised. Upstream fills the cache with `float("NaN")` and gets away with it by slicing the unwritten tail off before attention; a fixed-capacity graph cannot slice, and a masked SDPA still multiplies V by a zero weight, so `0 * NaN = NaN` poisons the cache silently. FluidAudio hit the same thing independently on their Core ML route. The existing NaN entries in `knowledge/` are all fp16 overflow, which is a different mechanism. Happy to write this up as a note if you want it separated from the card.

The port also produced five verified Core AI bugs with minimal repros, summarised on the card, drafted for Feedback Assistant and not yet filed. The in-graph KV write index one is an independent second sighting of `coreai-beta-mpsgraph-kvwrite-bug.md`, arrived at before I found that file, and resolved with the same one-hot write mask escape.

Happy to take the `CoreAIKit` pipeline at enrollment as discussed in #11.
