### PR TITLE
parakeet-v2: the English-only checkpoint alongside the enrolled v3 port

### DIFF
--- a/conversion/_parakeet_hf_upload.py
+++ b/conversion/_parakeet_hf_upload.py
@@ -1,78 +1,130 @@
-"""Stage + upload the Parakeet-TDT-0.6B Core AI bundle to HF. USER-GATED — run only when asked.
+"""Stage + upload a Parakeet-TDT-0.6B Core AI bundle to HF. USER-GATED — run only when asked.
 
-Stages the 30 s encoder (fp16) + predict/joint (fp32) .aimodels + tokenizer (with the
-swift-transformers-compatible `tokenizer_class`) + the librosa-slaney mel filterbank + a cc-by-4.0
-model card into /tmp/parakeet_hf, then uploads to mlboydaisuke/Parakeet-TDT-0.6B-CoreAI.
+Stages the 30 s encoder (fp16) + predict/joint (fp32) `.aimodel`s, the tokenizer assets
+(`parakeet/stage_bundle_assets.py`, which retags `tokenizer_class` for swift-transformers),
+the librosa-slaney mel filterbank and a cc-by-4.0 model card, then uploads the lot.
 
-    coreai-models/.venv/bin/python conversion/_parakeet_hf_upload.py
+Two checkpoints share this script because they share an architecture — v3 (25 European
+languages, vocab 8193) and v2 (English-only, vocab 1025, better English WER). Their bundle
+*filenames are identical*, so they cannot share a Hugging Face repo: `--repo` picks the
+target and `--artifacts` picks which conversion's bundles go into it. `--variant` just
+supplies the defaults for one of the two.
+
+    coreai-models/.venv/bin/python conversion/_parakeet_hf_upload.py --variant v3
+    coreai-models/.venv/bin/python conversion/_parakeet_hf_upload.py --variant v2 --stage-only
 """
-import os, json, shutil
-os.environ["HF_HUB_DISABLE_XET"] = "1"
+import argparse
+import os
+import shutil
+import sys
 from pathlib import Path
-from huggingface_hub import HfApi
 
-REPO = "mlboydaisuke/Parakeet-TDT-0.6B-CoreAI"
+os.environ["HF_HUB_DISABLE_XET"] = "1"
+
 HERE = Path(__file__).resolve().parent
-ART = HERE / "parakeet" / "artifacts"
-ASSETS = ART / "bundle_assets"
-STAGE = Path("/tmp/parakeet_hf")
+sys.path.insert(0, str(HERE / "parakeet"))
+from stage_bundle_assets import MEL_FILE, stage  # noqa: E402
+
+BUNDLES = ["parakeet_encoder_float16_L2885.aimodel", "parakeet_predict_float32.aimodel",
+           "parakeet_joint_float32.aimodel"]
+
+VARIANTS = {
+    "v3": {
+        "repo": "mlboydaisuke/Parakeet-TDT-0.6B-CoreAI",
+        "artifacts": "artifacts",
+        "hf_id": "nvidia/parakeet-tdt-0.6b-v3",
+        "title": "Parakeet-TDT-0.6B — Core AI",
+        "vocab": 8193, "blank": 8192, "tokens": 77,
+        "languages": "25 European languages",
+        "extra": "the first **transducer / TDT (RNN-T family)** ASR in the zoo",
+        "swift_note": ", and again token-exact through the Swift **CoreAIKit** "
+                      "`KitParakeetModel`",
+        "use_init": "try await KitParakeetModel(model: .parakeetTDT)",
+    },
+    "v2": {
+        "repo": "rahulrachuri/parakeet-tdt-0.6b-v2-coreai",
+        "artifacts": "artifacts_v2",
+        "hf_id": "nvidia/parakeet-tdt-0.6b-v2",
+        "title": "Parakeet-TDT-0.6B-v2 — Core AI",
+        "vocab": 1025, "blank": 1024, "tokens": 82,
+        "languages": "English",
+        "extra": "the **English-specialist** sibling of the v3 port (lower English WER, "
+                 "1025-entry vocabulary)",
+    },
+}
 
 CARD = """---
 license: cc-by-4.0
 library_name: coreai
 pipeline_tag: automatic-speech-recognition
-base_model: nvidia/parakeet-tdt-0.6b-v3
+base_model: {hf_id}
 tags: [core-ai, coreaikit, parakeet, tdt, rnn-t, transducer, asr, on-device, apple]
 ---
 
-# Parakeet-TDT-0.6B — Core AI
+# {title}
 
-[`nvidia/parakeet-tdt-0.6b-v3`](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3) (cc-by-4.0, 600M)
-converted to **Apple Core AI** `.aimodel` — the first **transducer / TDT (RNN-T family)** ASR in the
-[zoo](https://github.com/john-rocky/coreai-models-community). Transcribes ≤~29 s clips in 25
-European languages as **three stateless graphs + a host greedy loop** (no LLM runtime).
+[`{hf_id}`](https://huggingface.co/{hf_id}) (cc-by-4.0, 600M) converted to **Apple Core AI**
+`.aimodel` — {extra}
+([zoo](https://github.com/john-rocky/coreai-models-community)). Transcribes ≤~29 s clips in
+{languages} as **three stateless graphs + a host greedy loop** (no LLM runtime).
 
 - `parakeet_encoder_float16_L2885.aimodel` — FastConformer encoder + projector (fp16, ~1.2 GB),
   `mel[1,128,2885] → enc_proj[1,361,640]`.
 - `parakeet_predict_float32.aimodel` — embedding → 2-layer LSTM → projector (fp32),
   `token[1,1],h,c[2,1,640] → dec_out[1,640],h',c'`.
 - `parakeet_joint_float32.aimodel` — `head(relu(enc_frame+dec_out))` (fp32),
-  `→ token_logits[1,8193], dur_logits[1,5]`.
-- `tokenizer.json` (+ `tokenizer_config.json`), `mel_filters_128x257_f32.bin` (librosa-slaney).
+  `→ token_logits[1,{vocab}], dur_logits[1,5]`.
+- `tokenizer.json` (+ `tokenizer_config.json`), `{mel_file}` (librosa-slaney).
 
-Gated **77/77 token-exact** end-to-end vs the HF `ParakeetForTDT` reference, and again token-exact
-through the Swift **CoreAIKit** `KitParakeetModel`. blank 8192 · durations [0,1,2,3,4] · 16 kHz.
+Gated **{tokens}/{tokens} token-exact** end-to-end vs the HF `ParakeetForTDT` reference.
+blank {blank} · durations [0,1,2,3,4] · 16 kHz.
 
 ## Use (CoreAIKit)
 
 ```swift
-let parakeet = try await KitParakeetModel(model: .parakeetTDT)
+let parakeet = try await KitParakeetModel(bundleAt: bundleDirectory)
 let result = try await parakeet.transcribe(samples: pcm16kMono)   // 16 kHz mono Float
 ```
 """
 
 
 def main() -> None:
-    if STAGE.exists():
-        shutil.rmtree(STAGE)
-    STAGE.mkdir(parents=True)
-    for name in ["parakeet_encoder_float16_L2885.aimodel", "parakeet_predict_float32.aimodel",
-                 "parakeet_joint_float32.aimodel"]:
-        shutil.copytree(ART / name, STAGE / name)
-    for f in ["tokenizer.json", "mel_filters_128x257_f32.bin"]:
-        shutil.copy2(ASSETS / f, STAGE / f)
-    # swift-transformers (CoreAIKit) has no "ParakeetTokenizer"; retag to a registered class that
-    # maps to BPETokenizer. Decode is driven by tokenizer.json's Metaspace decoder, so this is exact.
-    cfg = json.loads((ASSETS / "tokenizer_config.json").read_text())
-    cfg["tokenizer_class"] = "PreTrainedTokenizer"
-    (STAGE / "tokenizer_config.json").write_text(json.dumps(cfg, indent=2))
-    (STAGE / "README.md").write_text(CARD)
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--variant", choices=sorted(VARIANTS), default="v3",
+                    help="which checkpoint's bundle to publish (supplies the defaults below)")
+    ap.add_argument("--repo", help="target HF repo id (default: the variant's)")
+    ap.add_argument("--artifacts", help="bundle dir under conversion/parakeet/ (default: the variant's)")
+    ap.add_argument("--hf-id", help="source checkpoint, or a local dir in HF layout, for the "
+                                    "tokenizer assets (default: the variant's)")
+    ap.add_argument("--stage", default=None, help="staging directory (default: /tmp/parakeet_hf_<variant>)")
+    ap.add_argument("--stage-only", action="store_true", help="build the upload directory, do not upload")
+    args = ap.parse_args()
+
+    v = VARIANTS[args.variant]
+    repo = args.repo or v["repo"]
+    art = HERE / "parakeet" / (args.artifacts or v["artifacts"])
+    hf_id = args.hf_id or v["hf_id"]
+    stage_dir = Path(args.stage) if args.stage else Path(f"/tmp/parakeet_hf_{args.variant}")
+
+    if stage_dir.exists():
+        shutil.rmtree(stage_dir)
+    stage_dir.mkdir(parents=True)
+    for name in BUNDLES:
+        shutil.copytree(art / name, stage_dir / name)
+    stage(hf_id, stage_dir)
+    (stage_dir / "README.md").write_text(CARD.format(mel_file=MEL_FILE, **v, hf_id=hf_id))
+    print(f"[stage] {stage_dir} -> {repo}")
+
+    if args.stage_only:
+        print("[stage-only] not uploading")
+        return
+    from huggingface_hub import HfApi
 
     api = HfApi()
-    api.create_repo(REPO, repo_type="model", exist_ok=True)
-    api.upload_folder(folder_path=str(STAGE), repo_id=REPO, repo_type="model",
-                      commit_message="Parakeet-TDT-0.6B -> Core AI: encoder + predict + joint + tokenizer")
-    print("uploaded", REPO)
+    api.create_repo(repo, repo_type="model", exist_ok=True)
+    api.upload_folder(folder_path=str(stage_dir), repo_id=repo, repo_type="model",
+                      commit_message=f"{v['title']}: encoder + predict + joint + tokenizer")
+    print("uploaded", repo)
 
 
 if __name__ == "__main__":

--- a/conversion/parakeet/.gitignore
+++ b/conversion/parakeet/.gitignore
@@ -2,4 +2,5 @@
 # `artifacts` is a symlink to artifacts_hf, so it needs the no-slash form.
 artifacts
 artifacts_hf/
+artifacts_*/
 *.npz

--- a/conversion/parakeet/export_decoder.py
+++ b/conversion/parakeet/export_decoder.py
@@ -6,8 +6,12 @@ Two tiny static graphs drive the transducer; the host runs the loop:
   predict : token[1,1] i32 + h[2,1,640] + c[2,1,640] -> dec_out[1,640] + h'[2,1,640] + c'[2,1,640]
             (embedding -> 2× manual LSTM cell -> decoder_projector; nn.LSTM avoided per the
              Kokoro lesson — single-step, so it's just two cell steps)
-  joint   : dec_out[1,640] + enc_frame[1,640] -> token_logits[1,8193] + dur_logits[1,5]
+  joint   : dec_out[1,640] + enc_frame[1,640] -> token_logits[1,V] + dur_logits[1,D]
             (head(relu(enc + dec)), split into the token and duration heads)
+
+The vocab is the one thing v2 and v3 disagree on — V=1025/blank 1024 vs V=8193/blank 8192 — so
+it is read from the oracle bundle rather than hardcoded, and `--hf-id` picks the checkpoint
+(an HF repo id, or a local dir in HF layout for v2).
 
 Gate ladder:
   1. eager re-author: run the host loop on golden enc_proj -> tokens must equal oracle tokens,
@@ -29,15 +33,15 @@ import torch
 import torch.nn as nn
 
 HERE = Path(__file__).resolve().parent
-HID, NL, VOCAB, NDUR, BLANK = 640, 2, 8193, 5, 8192
-DURATIONS = [0, 1, 2, 3, 4]
+DEFAULT_HF_ID = "nvidia/parakeet-tdt-0.6b-v3"
+HID, NL = 640, 2
 
 
 # --------------------------------------------------------------------------- modules
 class Predict(nn.Module):
-    def __init__(self):
+    def __init__(self, vocab: int):
         super().__init__()
-        self.embedding = nn.Embedding(VOCAB, HID)
+        self.embedding = nn.Embedding(vocab, HID)
         self.decoder_projector = nn.Linear(HID, HID, bias=True)
         for l in range(NL):
             self.register_buffer(f"w_ih{l}", torch.zeros(4 * HID, HID), persistent=True)
@@ -62,19 +66,30 @@ class Predict(nn.Module):
 
 
 class Joint(nn.Module):
-    def __init__(self):
+    def __init__(self, vocab: int, ndur: int):
         super().__init__()
-        self.head = nn.Linear(HID, VOCAB + NDUR, bias=True)
+        self.vocab = vocab
+        self.head = nn.Linear(HID, vocab + ndur, bias=True)
 
     def forward(self, dec_out, enc_frame):  # [1,640] each
-        logits = self.head(torch.relu(enc_frame + dec_out))   # [1,8198]
-        return logits[:, :VOCAB], logits[:, VOCAB:]
+        logits = self.head(torch.relu(enc_frame + dec_out))   # [1,V+D]
+        return logits[:, :self.vocab], logits[:, self.vocab:]
 
 
-def load_weights(predict: Predict, joint: Joint):
-    from safetensors import safe_open
+def weights_file(hf_id: str) -> str:
+    """model.safetensors for an HF repo id, or for a local dir in HF layout (how v2 arrives:
+    nvidia/parakeet-tdt-0.6b-v2 publishes only the .nemo, converted with transformers'
+    models/parakeet/convert_nemo_to_hf.py)."""
+    local = Path(hf_id) / "model.safetensors"
+    if local.is_file():
+        return str(local)
     from huggingface_hub import hf_hub_download
-    p = hf_hub_download("nvidia/parakeet-tdt-0.6b-v3", "model.safetensors")
+    return hf_hub_download(hf_id, "model.safetensors")
+
+
+def load_weights(predict: Predict, joint: Joint, hf_id: str):
+    from safetensors import safe_open
+    p = weights_file(hf_id)
     with safe_open(p, framework="pt") as f:
         predict.embedding.weight.data.copy_(f.get_tensor("decoder.embedding.weight"))
         predict.decoder_projector.weight.data.copy_(f.get_tensor("decoder.decoder_projector.weight"))
@@ -90,21 +105,21 @@ def load_weights(predict: Predict, joint: Joint):
 
 
 # --------------------------------------------------------------------------- TDT host loop
-def tdt_decode(predict_fn, joint_fn, enc_proj, T, collect_logits=False):
+def tdt_decode(predict_fn, joint_fn, enc_proj, T, blank, durations, collect_logits=False):
     """predict_fn(token,h,c)->(dec,h,c) ; joint_fn(dec,enc_frame)->(tl,dl). enc_proj[T,640]."""
     h = torch.zeros(NL, 1, HID)
     c = torch.zeros(NL, 1, HID)
-    dec, h, c = predict_fn(torch.tensor([[BLANK]]), h, c)
+    dec, h, c = predict_fn(torch.tensor([[blank]]), h, c)
     frame, emitted, logits_log = 0, [], []
     while frame < T and len(logits_log) < 12 * T:
         tl, dl = joint_fn(dec, enc_proj[frame:frame + 1])
-        token = int(tl.argmax()); dur = DURATIONS[int(dl.argmax())]
+        token = int(tl.argmax()); dur = durations[int(dl.argmax())]
         if collect_logits:
             logits_log.append(torch.cat([tl[0], dl[0]]).detach().numpy())
-        if token == BLANK and dur == 0:
+        if token == blank and dur == 0:
             dur = 1
         frame += dur
-        if token != BLANK:
+        if token != blank:
             emitted.append(token)
             dec, h, c = predict_fn(torch.tensor([[token]]), h, c)
     return emitted, logits_log
@@ -112,23 +127,34 @@ def tdt_decode(predict_fn, joint_fn, enc_proj, T, collect_logits=False):
 
 def main():
     ap = argparse.ArgumentParser()
+    ap.add_argument("--hf-id", default=DEFAULT_HF_ID, help="HF repo id, or a local dir in HF layout")
     ap.add_argument("--dtype", choices=["float32", "float16"], default="float32")
+    ap.add_argument("--oracle", default="oracle.npz")
+    ap.add_argument("--artifacts", default="artifacts", help="output dir (relative to this script)")
     ap.add_argument("--skip-export", action="store_true")
     args = ap.parse_args()
 
-    d = np.load(HERE / "oracle.npz")
+    d = np.load(HERE / args.oracle)
     enc_proj = torch.from_numpy(d["enc_proj"]).float()      # [T,640] golden
     T = int(d["T_valid"])
     gold_tokens = d["tokens"].tolist()
     gold_logits = torch.from_numpy(d["step_logits"]).float()
     text = str(d["text"])
+    # Vocab geometry comes from the oracle, not a constant: v2 is 1025/blank 1024, v3 8193/8192.
+    vocab, blank = int(d["vocab_size"]), int(d["blank_id"])
+    durations = (d["durations"].tolist() if "durations" in d
+                 else list(range(int(d["n_durations"]))))
+    src = str(d["source"]) if "source" in d else None
+    if src and src != args.hf_id:
+        print(f"⚠️  {args.oracle} was generated from {src!r}, not {args.hf_id!r}")
+    print(f"[model] {args.hf_id}  vocab={vocab} blank={blank} durations={durations}")
 
-    predict, joint = Predict().eval(), Joint().eval()
-    load_weights(predict, joint)
+    predict, joint = Predict(vocab).eval(), Joint(vocab, len(durations)).eval()
+    load_weights(predict, joint, args.hf_id)
 
     # ---- 1. eager re-author gate ----
     with torch.no_grad():
-        emitted, logs = tdt_decode(predict, joint, enc_proj, T, collect_logits=True)
+        emitted, logs = tdt_decode(predict, joint, enc_proj, T, blank, durations, collect_logits=True)
     tok_ok = emitted == gold_tokens
     n = min(len(logs), gold_logits.shape[0])
     lcos = torch.nn.functional.cosine_similarity(
@@ -145,7 +171,7 @@ def main():
     import coreai.runtime as rt
     from coreai_models.export.macos import export_to_coreai
     dtype = torch.float16 if args.dtype == "float16" else torch.float32
-    art = HERE / "artifacts"; art.mkdir(exist_ok=True)
+    art = HERE / args.artifacts; art.mkdir(exist_ok=True)
 
     def export(mod, example, ins, outs, name):
         prog = export_to_coreai(mod.to(dtype), example, dynamic_shapes=None,
@@ -185,15 +211,15 @@ def main():
                     torch.from_numpy(r["dur_logits"].numpy().astype(np.float32)))
 
         h = torch.zeros(NL, 1, HID); c = torch.zeros(NL, 1, HID)
-        dec, h, c = await step_p(torch.tensor([[BLANK]]), h, c)
+        dec, h, c = await step_p(torch.tensor([[blank]]), h, c)
         frame, emitted = 0, []
         while frame < T and len(emitted) < 12 * T:
             tl, dl = await step_j(dec, enc_proj[frame:frame + 1])
-            token = int(tl.argmax()); dur = DURATIONS[int(dl.argmax())]
-            if token == BLANK and dur == 0:
+            token = int(tl.argmax()); dur = durations[int(dl.argmax())]
+            if token == blank and dur == 0:
                 dur = 1
             frame += dur
-            if token != BLANK:
+            if token != blank:
                 emitted.append(token)
                 dec, h, c = await step_p(torch.tensor([[token]]), h, c)
         return emitted

--- a/conversion/parakeet/export_encoder.py
+++ b/conversion/parakeet/export_encoder.py
@@ -13,6 +13,10 @@ Rel-pos attention is Transformer-XL (bias_u/bias_v + relative_k_proj + rel_shift
 positional table is a constant baked for the bucket length. Single full-length clip -> no
 attention mask (the golden clip fills the bucket exactly, L=1485 -> T=186).
 
+v2 and v3 share this encoder byte-for-byte in shape — only the tokenizer/vocab differ — so
+`--hf-id` (an HF repo id, or a local dir in HF layout for v2) is the only knob that changes
+between them, alongside `--artifacts` to keep the two variants' bundles apart.
+
 Run (MAIN venv; _GPU_LOCK held for the engine gate):
     coreai-models/.venv/bin/python export_encoder.py [--dtype float16] [--skip-export]
 """
@@ -28,6 +32,7 @@ import torch
 import torch.nn as nn
 
 HERE = Path(__file__).resolve().parent
+DEFAULT_HF_ID = "nvidia/parakeet-tdt-0.6b-v3"
 HID, HEADS, HDIM, FF, NLAYERS = 1024, 8, 128, 4096, 24
 MEL, SUB_CH, VOCAB_PROJ = 128, 256, 640
 CONV_K = 9
@@ -174,10 +179,20 @@ class Encoder(nn.Module):
         return self.projector(x)
 
 
-def load_weights(enc: Encoder):
-    from safetensors import safe_open
+def weights_file(hf_id: str) -> str:
+    """model.safetensors for an HF repo id, or for a local dir in HF layout (how v2 arrives:
+    nvidia/parakeet-tdt-0.6b-v2 publishes only the .nemo, converted with transformers'
+    models/parakeet/convert_nemo_to_hf.py)."""
+    local = Path(hf_id) / "model.safetensors"
+    if local.is_file():
+        return str(local)
     from huggingface_hub import hf_hub_download
-    p = hf_hub_download("nvidia/parakeet-tdt-0.6b-v3", "model.safetensors")
+    return hf_hub_download(hf_id, "model.safetensors")
+
+
+def load_weights(enc: Encoder, hf_id: str):
+    from safetensors import safe_open
+    p = weights_file(hf_id)
     sd = {}
     with safe_open(p, framework="pt") as f:
         for k in f.keys():
@@ -197,8 +212,10 @@ def load_weights(enc: Encoder):
 # --------------------------------------------------------------------------- gate/export
 def main():
     ap = argparse.ArgumentParser()
+    ap.add_argument("--hf-id", default=DEFAULT_HF_ID, help="HF repo id, or a local dir in HF layout")
     ap.add_argument("--dtype", choices=["float16", "float32"], default="float16")
     ap.add_argument("--oracle", default="oracle.npz")
+    ap.add_argument("--artifacts", default="artifacts", help="output dir (relative to this script)")
     ap.add_argument("--skip-export", action="store_true")
     args = ap.parse_args()
 
@@ -207,10 +224,15 @@ def main():
     golden = torch.from_numpy(d["enc_proj"]).float()       # [T,640]
     L = mel.shape[1]
     mel_in = mel.transpose(1, 2).contiguous()              # [1,128,L]
+    print(f"[model] {args.hf_id}")
     print(f"mel {tuple(mel_in.shape)} L={L} golden enc_proj {tuple(golden.shape)}")
+    # An oracle from a different checkpoint would gate the wrong weights against the wrong golden.
+    src = str(d["source"]) if "source" in d else None
+    if src and src != args.hf_id:
+        print(f"⚠️  {args.oracle} was generated from {src!r}, not {args.hf_id!r}")
 
     enc = Encoder(L).eval()
-    load_weights(enc)
+    load_weights(enc, args.hf_id)
     assert enc.T == golden.shape[0], f"T mismatch {enc.T} vs {golden.shape[0]}"
 
     with torch.no_grad():
@@ -240,7 +262,7 @@ def main():
         input_names=("mel",), output_names=("enc_proj",),
         state_names=None, externalize_modules=[])
     prog.optimize()
-    art = HERE / "artifacts"
+    art = HERE / args.artifacts
     art.mkdir(exist_ok=True)
     aimodel = art / f"parakeet_encoder_{args.dtype}_L{L}.aimodel"
     shutil.rmtree(aimodel, ignore_errors=True)

--- a/conversion/parakeet/gate_e2e.py
+++ b/conversion/parakeet/gate_e2e.py
@@ -7,6 +7,7 @@ held:
 """
 from __future__ import annotations
 
+import argparse
 import asyncio
 from pathlib import Path
 
@@ -16,9 +17,7 @@ import torch
 import coreai.runtime as rt
 
 HERE = Path(__file__).resolve().parent
-ART = HERE / "artifacts"
-HID, NL, VOCAB, BLANK = 640, 2, 8193, 8192
-DURATIONS = [0, 1, 2, 3, 4]
+HID, NL = 640, 2
 
 
 async def gpu(path):
@@ -27,17 +26,25 @@ async def gpu(path):
 
 
 async def main():
-    import sys
-    oracle = sys.argv[1] if len(sys.argv) > 1 else "oracle.npz"
-    d = np.load(HERE / oracle)
+    ap = argparse.ArgumentParser()
+    ap.add_argument("oracle", nargs="?", default="oracle.npz")
+    ap.add_argument("--artifacts", default="artifacts", help="bundle dir (relative to this script)")
+    args = ap.parse_args()
+    art = HERE / args.artifacts
+
+    d = np.load(HERE / args.oracle)
     mel = torch.from_numpy(d["input_features"]).float().transpose(1, 2).contiguous()  # [1,128,L]
     L = mel.shape[2]
     gold_tokens = d["tokens"].tolist()
     text = str(d["text"])
+    # v2 and v3 differ only here: blank 1024 / 8192, and the durations the joint indexes.
+    blank = int(d["blank_id"])
+    durations = (d["durations"].tolist() if "durations" in d
+                 else list(range(int(d["n_durations"]))))
 
-    enc_fn = await gpu(ART / f"parakeet_encoder_float16_L{L}.aimodel")
-    pf = await gpu(ART / "parakeet_predict_float32.aimodel")
-    jf = await gpu(ART / "parakeet_joint_float32.aimodel")
+    enc_fn = await gpu(art / f"parakeet_encoder_float16_L{L}.aimodel")
+    pf = await gpu(art / "parakeet_predict_float32.aimodel")
+    jf = await gpu(art / "parakeet_joint_float32.aimodel")
 
     # encoder (fp16) -> enc_proj
     r = await enc_fn({"mel": rt.NDArray(mel.half().numpy())})
@@ -58,15 +65,15 @@ async def main():
                 torch.from_numpy(o["dur_logits"].numpy().astype(np.float32)))
 
     h = torch.zeros(NL, 1, HID); c = torch.zeros(NL, 1, HID)
-    dec, h, c = await step_p(torch.tensor([[BLANK]]), h, c)
+    dec, h, c = await step_p(torch.tensor([[blank]]), h, c)
     frame, emitted = 0, []
     while frame < T and len(emitted) < 12 * T:
         tl, dl = await step_j(dec, enc_proj[frame:frame + 1])
-        token = int(tl.argmax()); dur = DURATIONS[int(dl.argmax())]
-        if token == BLANK and dur == 0:
+        token = int(tl.argmax()); dur = durations[int(dl.argmax())]
+        if token == blank and dur == 0:
             dur = 1
         frame += dur
-        if token != BLANK:
+        if token != blank:
             emitted.append(token)
             dec, h, c = await step_p(torch.tensor([[token]]), h, c)
 

--- a/conversion/parakeet/gate_mel_swift.py
+++ b/conversion/parakeet/gate_mel_swift.py
@@ -12,6 +12,7 @@ Run (MAIN venv, _GPU_LOCK held):
     coreai-models/.venv/bin/python gate_mel_swift.py
 """
 from __future__ import annotations
+import argparse
 import asyncio
 from pathlib import Path
 import numpy as np
@@ -20,9 +21,7 @@ import librosa
 import coreai.runtime as rt
 
 HERE = Path(__file__).resolve().parent
-ART = HERE / "artifacts"
-HID, NL, VOCAB, BLANK = 640, 2, 8193, 8192
-DURATIONS = [0, 1, 2, 3, 4]
+HID, NL = 640, 2
 N_FFT, WIN, HOP, NMELS = 512, 400, 160, 128
 BUCKET = 2885
 
@@ -105,7 +104,7 @@ async def gpu(path):
     return m.load_function("main")
 
 
-async def run_e2e(enc_fn, pf, jf, mel_np) -> list[int]:
+async def run_e2e(enc_fn, pf, jf, mel_np, blank, durations) -> list[int]:
     r = await enc_fn({"mel": rt.NDArray(mel_np.astype(np.float16))})
     enc_proj = torch.from_numpy(r["enc_proj"].numpy().astype(np.float32))[0]
     T = enc_proj.shape[0]
@@ -123,23 +122,32 @@ async def run_e2e(enc_fn, pf, jf, mel_np) -> list[int]:
                 torch.from_numpy(o["dur_logits"].numpy().astype(np.float32)))
 
     h = torch.zeros(NL, 1, HID); c = torch.zeros(NL, 1, HID)
-    dec, h, c = await step_p(torch.tensor([[BLANK]]), h, c)
+    dec, h, c = await step_p(torch.tensor([[blank]]), h, c)
     frame, emitted = 0, []
     while frame < T and len(emitted) < 12 * T:
         tl, dl = await step_j(dec, enc_proj[frame:frame + 1])
-        token = int(tl.argmax()); dur = DURATIONS[int(dl.argmax())]
-        if token == BLANK and dur == 0:
+        token = int(tl.argmax()); dur = durations[int(dl.argmax())]
+        if token == blank and dur == 0:
             dur = 1
         frame += dur
-        if token != BLANK:
+        if token != blank:
             emitted.append(token)
             dec, h, c = await step_p(torch.tensor([[token]]), h, c)
     return emitted
 
 
 async def main():
-    d = np.load(HERE / "oracle_30s.npz")
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--oracle", default="oracle_30s.npz")
+    ap.add_argument("--artifacts", default="artifacts", help="bundle dir (relative to this script)")
+    args = ap.parse_args()
+    ART = HERE / args.artifacts
+
+    d = np.load(HERE / args.oracle)
     gold = d["tokens"].tolist()
+    blank = int(d["blank_id"])
+    durations = (d["durations"].tolist() if "durations" in d
+                 else list(range(int(d["n_durations"]))))
 
     # the natural libri1 clip (no manual silence pad) — the realistic app input
     wav, _ = librosa.load(librosa.example("libri1"), sr=16000, mono=True)
@@ -153,7 +161,7 @@ async def main():
     for name, recipe in [("Y per-clip+zero-pad", recipe_Y), ("X oracle-style", recipe_X),
                          ("S manual-DFT swift-sim", recipe_swift)]:
         mel = recipe(wav)
-        emitted = await run_e2e(enc_fn, pf, jf, mel)
+        emitted = await run_e2e(enc_fn, pf, jf, mel, blank, durations)
         exact = emitted == gold
         same = sum(int(a == b) for a, b in zip(emitted, gold))
         txt = d["text"] if exact else "(differs)"

--- a/conversion/parakeet/gen_oracle.py
+++ b/conversion/parakeet/gen_oracle.py
@@ -1,6 +1,6 @@
 """Phase 1 — Parakeet TDT 0.6B golden oracle (run in the ISOLATED transformers-5.x env).
 
-Loads nvidia/parakeet-tdt-0.6b-v3, runs it on a real English clip, and saves a golden
+Loads a Parakeet TDT checkpoint, runs it on a real English clip, and saves a golden
 bundle that the Core-AI export/gate (main coreai-torch venv) compares against:
 
   oracle.npz
@@ -11,11 +11,14 @@ bundle that the Core-AI export/gate (main coreai-torch venv) compares against:
     step_frames      [S]           encoder frame index at each decode step
     step_tokens      [S]           argmax token at each step (incl. blanks)
     step_durations   [S]           argmax duration at each step
-    step_logits      [S,8198]      reference joint logits (token 0..8192 + dur 8193..8197)
+    step_logits      [S,V+D]       reference joint logits (V token logits, then D duration ones)
     text             ()            reference transcript (str)
-  + scalars: blank_id, start_token, vocab_size, n_durations, T_valid
+  + scalars: blank_id, start_token, vocab_size, n_durations, T_valid, source
+  + durations [D]  the duration values themselves — v2 and v3 agree, the exporters don't assume it
 
-Also asserts our hand-rolled greedy TDT loop == model.generate() (the loop we port to Swift).
+`--hf-id` also accepts a local directory in HF layout, which is how v2 is obtained:
+nvidia/parakeet-tdt-0.6b-v2 ships only the .nemo archive, so it has to be converted first
+with transformers' `models/parakeet/convert_nemo_to_hf.py` (main branch, not in the wheel).
 
 Run:  ~/code/coreai/_parakeet_oracle/.venv/bin/python gen_oracle.py [--seconds 16]
 """
@@ -27,7 +30,7 @@ from pathlib import Path
 import numpy as np
 import torch
 
-MODEL = "nvidia/parakeet-tdt-0.6b-v3"
+DEFAULT_HF_ID = "nvidia/parakeet-tdt-0.6b-v3"
 OUT = Path(__file__).resolve().parent / "oracle.npz"
 
 
@@ -44,6 +47,7 @@ def load_clip(seconds: float, pad_seconds: float = 0.0, sr: int = 16000) -> np.n
 @torch.no_grad()
 def main() -> None:
     ap = argparse.ArgumentParser()
+    ap.add_argument("--hf-id", default=DEFAULT_HF_ID, help="HF repo id, or a local dir in HF layout")
     ap.add_argument("--seconds", type=float, default=16.0)
     ap.add_argument("--pad-seconds", type=float, default=0.0, help="trailing silence to a fixed bucket")
     ap.add_argument("--out", default="oracle.npz")
@@ -53,18 +57,23 @@ def main() -> None:
 
     from transformers import AutoProcessor, ParakeetForTDT
 
-    processor = AutoProcessor.from_pretrained(MODEL)
-    model = ParakeetForTDT.from_pretrained(MODEL, dtype=torch.float32).eval()
+    processor = AutoProcessor.from_pretrained(args.hf_id)
+    model = ParakeetForTDT.from_pretrained(args.hf_id, dtype=torch.float32).eval()
     cfg = model.config
     blank = cfg.blank_token_id
     vocab = cfg.vocab_size
     durations = list(cfg.durations)
+    # The joint head emits the token logits first, then one logit per duration. v2's vocab is
+    # 1025 (blank 1024) against v3's 8193 (blank 8192), so the split point is read, never assumed.
+    assert model.joint.head.out_features == vocab + len(durations), (
+        f"joint head {model.joint.head.out_features} != vocab {vocab} + durations {len(durations)}")
     start = model.generation_config.decoder_start_token_id
     if start is None:
         start = blank
     # The joint network's activation is the TOP-level config.hidden_act (ReLU here),
     # NOT the encoder's silu — getting this wrong silently garbles the transcript.
     joint_act = torch.nn.functional.relu if cfg.hidden_act == "relu" else torch.nn.functional.silu
+    print(f"[model] {args.hf_id}")
     print(f"blank={blank} vocab={vocab} durations={durations} start_token={start} joint_act={cfg.hidden_act}")
 
     wav = load_clip(args.seconds, args.pad_seconds)
@@ -103,7 +112,7 @@ def main() -> None:
     step_frames, step_tokens, step_durs, step_logits = [], [], [], []
     max_steps = cfg.max_symbols_per_step * T + 16
     while frame < T and len(step_tokens) < max_steps:
-        logits = head(joint_act(enc_proj[frame] + dec_out))     # [8198]
+        logits = head(joint_act(enc_proj[frame] + dec_out))     # [vocab + n_durations]
         token = int(logits[:vocab].argmax())
         dur_idx = int(logits[vocab:].argmax())
         dur = durations[dur_idx]
@@ -138,7 +147,8 @@ def main() -> None:
         text=np.array(ref_text),
         blank_id=np.array(blank), start_token=np.array(start),
         vocab_size=np.array(vocab), n_durations=np.array(len(durations)),
-        T_valid=np.array(T),
+        durations=np.array(durations, dtype=np.int64),
+        T_valid=np.array(T), source=np.array(args.hf_id),
     )
     sz = OUT.stat().st_size / 1e6
     print(f"[save] {OUT} ({sz:.1f} MB)  {'✅ loop matches generate()' if match else '❌ MISMATCH'}")

--- a/conversion/parakeet/stage_bundle_assets.py
+++ b/conversion/parakeet/stage_bundle_assets.py
@@ -1,0 +1,90 @@
+"""Stage the three non-weight files a Parakeet bundle needs beside its `.aimodel` graphs.
+
+The graphs carry acoustics and logits; everything on either side of them is host work, and
+that host work needs assets:
+
+  tokenizer.json          the BPE + Metaspace decoder that turns emitted ids into text
+  tokenizer_config.json   retagged `tokenizer_class` -> "PreTrainedTokenizer", because
+                          swift-transformers rejects the upstream "ParakeetTokenizer"
+                          (`unsupportedTokenizer`). Decode is driven by tokenizer.json's
+                          Metaspace decoder, so the retag is exact, not an approximation.
+  mel_filters_128x257_f32.bin
+                          the librosa-slaney mel filterbank the Swift/Accelerate log-mel
+                          front end multiplies the power spectrum by, mel-major [128, 257]
+                          f32. Derived, not downloaded — it is a function of
+                          (sr 16000, n_fft 512, n_mels 128, fmin 0, fmax 8000, slaney).
+
+Both consumers read the same staged directory: `ParakeetSelfTest.swift` copies the two
+tokenizer files out of `<artifacts>/bundle_assets/`, and `_parakeet_hf_upload.py` publishes
+all three. Staging them once is what keeps a v2 bundle from shipping v3's tokenizer — the
+vocabularies are 1025 and 8193 entries, so a mismatch is silent garbage, not an error.
+
+    ../../.venv/bin/python stage_bundle_assets.py \
+        --hf-id ../../../parakeet-v2-hf --artifacts artifacts_v2
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+
+import numpy as np
+
+HERE = Path(__file__).resolve().parent
+
+# swift-transformers has no "ParakeetTokenizer"; this is the registered class that maps to
+# BPETokenizer. See models/parakeet/README.md lesson 4.
+SWIFT_TOKENIZER_CLASS = "PreTrainedTokenizer"
+
+MEL = dict(sr=16000, n_fft=512, n_mels=128, fmin=0.0, fmax=8000.0, norm="slaney")
+MEL_FILE = "mel_filters_128x257_f32.bin"
+
+
+def _source_file(hf_id: str, name: str) -> Path:
+    """`name` from a local HF-layout directory, or from the Hub cache."""
+    local = Path(hf_id).expanduser()
+    if local.is_dir():
+        return local / name
+    from huggingface_hub import hf_hub_download
+
+    return Path(hf_hub_download(hf_id, name))
+
+
+def stage(hf_id: str, dest: Path) -> Path:
+    """Write the tokenizer pair + mel filterbank into `dest`. Returns `dest`."""
+    import librosa
+
+    dest.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(_source_file(hf_id, "tokenizer.json"), dest / "tokenizer.json")
+
+    cfg = json.loads(_source_file(hf_id, "tokenizer_config.json").read_text())
+    cfg["tokenizer_class"] = SWIFT_TOKENIZER_CLASS
+    (dest / "tokenizer_config.json").write_text(json.dumps(cfg, indent=2))
+
+    fb = librosa.filters.mel(**MEL).astype(np.float32)  # [128, 257], mel-major
+    assert fb.shape == (128, 257), fb.shape
+    fb.tofile(dest / MEL_FILE)
+
+    # Report the id space the joint head has to match. Counting entries would be wrong:
+    # <unk> is an added token that *reuses* id 0, so the highest id is the only honest
+    # measure (v2 -> 1025 with <blank> at 1024; v3 -> 8193 with <blank> at 8192).
+    tok = json.loads((dest / "tokenizer.json").read_text())
+    ids = 1 + max([*tok["model"]["vocab"].values(),
+                   *(a["id"] for a in tok.get("added_tokens", []))])
+    print(f"[assets] {dest}  tokenizer ids {ids}  mel {fb.shape}")
+    return dest
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--hf-id", default="nvidia/parakeet-tdt-0.6b-v3",
+                    help="HF repo id, or a local dir in HF layout")
+    ap.add_argument("--artifacts", default="artifacts",
+                    help="bundle dir (relative to this script); assets land in its bundle_assets/")
+    args = ap.parse_args()
+    stage(args.hf_id, HERE / args.artifacts / "bundle_assets")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/parakeet-v2/README.md
+++ b/models/parakeet-v2/README.md
@@ -1,0 +1,117 @@
+# Parakeet-TDT-0.6B-v2 — Core AI
+
+The **English-specialist sibling** of the zoo's [`parakeet`](../parakeet/README.md) entry.
+[`nvidia/parakeet-tdt-0.6b-v2`](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2)
+(cc-by-4.0, 600M) is the same token-and-duration transducer architecture as the enrolled
+v3 port — FastConformer encoder, LSTM predictor, joint network with a duration head,
+three stateless `.aimodel` graphs plus a host-driven greedy loop — trained for English
+alone rather than 25 European languages.
+
+The two differ where the vocabulary does: v2 has **1025 entries with blank at 1024**,
+against v3's 8193 with blank at 8192. Everything else in the pipeline is shared, which is
+why both checkpoints export from one pair of scripts here rather than a fork.
+
+## Why v2 alongside v3
+
+v3 buys 25 languages; v2 spends the same 600M parameters on English only. For
+English-only long-form transcription that is a trade worth having both sides of, and this
+port exists because its author runs v2 in production for exactly that reason. It is also
+the ASR that gates the pocket-tts port's acceptance ladder, so it already does work
+inside this catalog.
+
+Related: [apple/coreai-models#163](https://github.com/apple/coreai-models/issues/163) asks
+for v2 support alongside the v3 support that landed in that repo's #136.
+
+## Pipeline
+
+```
+audio 16 kHz ──(host: librosa-slaney mel, 128 × 2885)──▶
+  1. parakeet_encoder_float16_L2885.aimodel   mel[1,128,2885] -> enc_proj[1,361,640]
+  2. parakeet_predict_float32.aimodel         token[1,1], h,c[2,1,640] -> dec_out[1,640], h', c'
+  3. parakeet_joint_float32.aimodel           relu(enc_frame + dec_out) -> token_logits[1,1025],
+                                                                          dur_logits[1,5]
+host: greedy TDT loop — blanks advance time, non-blank tokens advance the predictor,
+      the duration head decides how many frames to skip. durations [0,1,2,3,4].
+```
+
+L2885 is 30 s of mel frames baked into the graph, giving T = 361 encoder frames.
+
+## Gates
+
+Full transcript ships beside the bundles as `gates_v2.txt`. Reference is HF
+`ParakeetForTDT` on the converted checkpoint; the clip is 14.84 s of librispeech speech
+plus trailing silence into the L2885 bucket, 82 gold tokens.
+
+| gate | result |
+|---|---|
+| encoder, eager fp32 | global cos 1.000006, per-token mean 1.000000, max abs 0.0 |
+| encoder, `cpu_only` | per-token cos mean 0.999911, min 0.998284, max abs 0.430 — PASS |
+| encoder, `gpu` | per-token cos mean 0.999998, min 0.999970, max abs 0.055 — PASS |
+| decoder, eager | 82/82 tokens exact, step-logit cos 1.000000 |
+| decoder, engine `gpu` | 82/82 tokens, exact — PASS |
+| end to end, `gpu` | 82/82 emitted, token-agree 82/82, exact — PASS |
+
+The mel gate is worth reading in the transcript rather than the table. Feeding per-clip
+mel with zero padding emits 85 tokens against 82 gold and agrees on only 22, while the
+oracle-style path and a manual-DFT Swift simulation are both 82/82 exact. The padding
+convention is load-bearing, and a host that gets it wrong fails quietly with plausible
+text.
+
+## Speed
+
+M4 Pro, over a 340-minute long-form corpus at the published precision: **291× realtime at
+peak**, about 284× typical, and roughly 260× with the machine under normal desktop load.
+
+iPhone 17 Pro Max (`iPhone18,2`), iOS 27.0 (build 24A5408d), Release, charging, encoder
+on gpu with predictor and joint on cpu, stream depth 2, one decode worker. Corpus is 152
+chunks over 3989.9 s (66 minutes) of audio.
+
+| metric | value |
+|---|---:|
+| RTF excluding load | **175.3× realtime** |
+| RTF including load | 173.3× |
+| load | 0.27 s |
+| peak RSS | 1458 MB |
+| accuracy over the run | 152/152 chunks token-exact, 20376/20376 tokens (100.0000 %) |
+
+Thermal state went nominal to fair across the 66-minute run, with per-chunk time drifting
+from about 0.50 s to about 0.78 s as it did. Of the compute, the encoder is 73.78 s and
+the TDT loop 11.40 s, and 90 % of that loop is predictor dispatch at 500 µs across 20528
+calls — the decode side is dispatch-bound, not compute-bound.
+
+## Bundles
+
+[`rahulrachuri/parakeet-tdt-0.6b-v2-coreai`](https://huggingface.co/rahulrachuri/parakeet-tdt-0.6b-v2-coreai),
+cc-by-4.0 inherited from the model.
+
+| bundle | size | role |
+|---|---:|---|
+| `parakeet_encoder_float16_L2885.aimodel` | 1165 MB | FastConformer encoder + projector |
+| `parakeet_predict_float32.aimodel` | 30 MB | embedding, 2-layer LSTM, projector |
+| `parakeet_joint_float32.aimodel` | 3 MB | joint network, token + duration heads |
+
+The repo also carries the tokenizer assets, the librosa-slaney mel filterbank, the gate
+transcript, and the converter patch described below.
+
+## Converting the checkpoint
+
+NVIDIA publishes v2 as a `.nemo` only, so the HF-layout checkpoint the exporters read is
+itself a conversion, published as
+[`rahulrachuri/parakeet-tdt-0.6b-v2`](https://huggingface.co/rahulrachuri/parakeet-tdt-0.6b-v2).
+It needed two fixes to transformers' `convert_nemo_to_hf.py`, both because v2's NeMo vocab
+has 1024 labels and, unlike v3's, carries no `<pad>`:
+
+- `write_processor` must take the RNN-T ordering when a TDT vocab has no `<pad>`, so
+  `<blank>` lands on id 1024, the model's own `blank_token_id`. Stock adds `<pad>` at 1024
+  and `<blank>` at 1025, which is off by one.
+- `convert_tdt_config` must fall back to `blank_token_id` when `<pad>` is absent. Stock
+  raises `ValueError: '<pad>' is not in list`.
+
+The patch ships beside the bundles as `convert_nemo_to_hf_v2.patch`.
+
+## Licence
+
+Model weights are cc-by-4.0 from NVIDIA and carry that licence into the converted
+bundles. The conversion scripts here follow this repository's licence, and the Swift host
+[parakeet-swift](https://github.com/RahulRachuri/parakeet-swift) is separate and
+distributes no weights.

--- a/models/parakeet-v2/recipe.toml
+++ b/models/parakeet-v2/recipe.toml
@@ -1,0 +1,24 @@
+# Recipe for parakeet-v2 — the configuration that produced each published bundle.
+# Schema and the rules for `status`: ../README.md.
+# Run it with:  python3 ../../conversion/zoo_convert.py run <name>
+
+["parakeet-tdt-0.6b-v2"]
+card = "README.md"
+hf_repo = "rahulrachuri/parakeet-tdt-0.6b-v2-coreai"
+source_hf_id = "nvidia/parakeet-tdt-0.6b-v2"
+status = "verified"
+steps = [
+  { script = "parakeet/export_encoder.py", args = ["--hf-id", "rahulrachuri/parakeet-tdt-0.6b-v2", "--oracle", "oracle_v2_30s.npz", "--artifacts", "artifacts_v2"], bundle = "parakeet_encoder_float16_L2885.aimodel" },
+  { script = "parakeet/export_decoder.py", args = ["--hf-id", "rahulrachuri/parakeet-tdt-0.6b-v2", "--dtype", "float32", "--oracle", "oracle_v2_30s.npz", "--artifacts", "artifacts_v2"], bundle = "parakeet_predict_float32.aimodel" },
+]
+notes = [
+  "Same two exporters as the v3 recipe; --hf-id is the only knob that changes the checkpoint.",
+  "NVIDIA publishes v2 as a .nemo only, so --hf-id points at an HF-layout conversion rather than",
+  "an NVIDIA repo. That conversion needed two fixes to transformers' convert_nemo_to_hf.py,",
+  "because v2's vocab has 1024 labels and carries no <pad> where v3's does; the patch ships",
+  "beside the bundles as convert_nemo_to_hf_v2.patch.",
+  "The oracle differs from v3's (oracle_v2_30s.npz, vocab 1025 / blank 1024), so generate it",
+  "first with gen_oracle.py --hf-id <the same id> --seconds 16 --pad-seconds 14.0.",
+  "The encoder takes no length flag — L2885 (30 s of frames) is baked into the graph. One",
+  "decoder run emits both published float32 graphs (predict + joint).",
+]


### PR DESCRIPTION
Adds [`nvidia/parakeet-tdt-0.6b-v2`](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2) as a catalog entry beside your enrolled v3 port.

To be clear about what this is not: parakeet is yours, v3 is enrolled, and the TDT decoding story, the three-graph shape and the host greedy loop are all settled ground here. This only adds the English-only checkpoint, and it does it by making `--hf-id` the knob that picks the checkpoint rather than forking your exporters. v3 remains the default everywhere.

Related upstream: [apple/coreai-models#163](https://github.com/apple/coreai-models/issues/163) asks Apple for v2 alongside the v3 support that landed in their #136.

## Why v2 is worth its own entry

Same 600M TDT architecture, different training target: v3 spends it on 25 European languages, v2 on English alone. The vocabularies differ accordingly, 1025 entries with blank at 1024 against v3's 8193 and 8192, and nothing else in the pipeline changes. For English-only long-form transcription the trade is worth having both sides of, which is why I run v2 in production and why my Swift host targets it. It is also the ASR that gates the pocket-tts port in #12.

## Gates

Reference is HF `ParakeetForTDT` on the converted checkpoint, 14.84 s of librispeech speech plus trailing silence into the L2885 bucket, 82 gold tokens. Full transcript ships beside the bundles as `gates_v2.txt`.

| gate | result |
|---|---|
| encoder, eager fp32 | cos 1.000006, per-token mean 1.000000 |
| encoder, `cpu_only` | cos mean 0.999911, min 0.998284 — PASS |
| encoder, `gpu` | cos mean 0.999998, min 0.999970 — PASS |
| decoder, eager | 82/82 exact, step-logit cos 1.000000 |
| end to end, `gpu` | 82/82, token-agree 82/82 — PASS |

The mel gate is the one worth reading. Per-clip mel with zero padding emits 85 tokens against 82 gold and agrees on only 22, while the oracle-style path and a manual-DFT Swift simulation are both 82/82 exact. The padding convention is load-bearing and a host that gets it wrong fails quietly with plausible text.

## Speed

M4 Pro, 340-minute long-form corpus at the published precision: **291× realtime at peak**, about 284× typical, roughly 260× under normal desktop load.

Device is iPhone 17 Pro Max, iOS 27.0 (24A5408d), Release, encoder on gpu with predictor and joint on cpu, stream depth 2, one decode worker. 152 chunks over 3989.9 s of audio.

| metric | value |
|---|---:|
| RTF excluding load | **175.3×** |
| RTF including load | 173.3× |
| load | 0.27 s |
| peak RSS | 1458 MB |
| accuracy across the run | 152/152 chunks exact, 20376/20376 tokens (100.0000%) |

Thermal went nominal to fair over the 66 minutes, per-chunk drifting 0.50 s to 0.78 s. Of compute, encoder is 73.78 s and the TDT loop 11.40 s, and 90% of that loop is predictor dispatch at 500 µs over 20528 calls, so decode is dispatch-bound rather than compute-bound.

## Checks

- `zoo_verify.py rahulrachuri/parakeet-tdt-0.6b-v2-coreai` → 3 bundles, PASS 3, DIFF 0, FAIL 0
- `zoo_convert.py show parakeet-tdt-0.6b-v2` → prints both export commands
- Bundles: [rahulrachuri/parakeet-tdt-0.6b-v2-coreai](https://huggingface.co/rahulrachuri/parakeet-tdt-0.6b-v2-coreai)

## A side contribution you may care about independently

NVIDIA publishes v2 as a `.nemo` only, so the HF-layout checkpoint the exporters read had to be made. It needed two fixes to transformers' `convert_nemo_to_hf.py`, both because v2's NeMo vocab has 1024 labels and, unlike v3's, carries no `<pad>`: `write_processor` must take the RNN-T ordering so `<blank>` lands on 1024 rather than stock's off-by-one, and `convert_tdt_config` must fall back to `blank_token_id` instead of raising on the missing `<pad>`.

The result is published as [rahulrachuri/parakeet-tdt-0.6b-v2](https://huggingface.co/rahulrachuri/parakeet-tdt-0.6b-v2) and the patch ships beside the bundles. As far as I can tell it is the only HF-layout v2 checkpoint that exists, so anyone else porting v2 currently has to rediscover both fixes.

## One thing I want your call on before you review too closely

Two commits here add an iOS/ANE encoder authoring track and an encoder export at arbitrary static mel length. **You have already landed an iOS AOT-encoder sideload path**, so these may be redundant or actively conflicting with it, and I would rather hear that now than at review. If they overlap, say so and I will drop both commits and leave this PR as the checkpoint selection plus the card and recipe, which is the part that stands alone.

Separately, if you would rather v2 lived as a selectable checkpoint under the existing `models/parakeet/` entry than as its own `models/parakeet-v2/`, that is a small change and the packaging call is yours.

Also filed [apple/coreai-models#164](https://github.com/apple/coreai-models/issues/164) along the way, where `SpeechRecognitionModel` estimates `validEncoderFrames` proportionally when the subsampling arithmetic determines it exactly. Apple has assigned it.
