### PR TITLE
pocket-tts: the corrections I owed the note, and the builds the numbers came from

### DIFF
--- a/knowledge/pocket-tts-port.md
+++ b/knowledge/pocket-tts-port.md
@@ -64,11 +64,14 @@ heterogeneous allowed set, not an op.**
   `Allowed: [CPU, GPU, Neural Engine] / Preferred: CPU`, the same with `Preferred: GPU`, and
   `Allowed: [CPU] / Preferred: None`.
 - It scales with **how much there is to partition**, not with size or dtype. In the pocket-tts
-  repro a 6-layer prefill over 16 positions and a multi-stage convolutional decoder both fail,
-  while the same transformer at 1 position and a small stateless function are correct.
+  repro the two failing graphs are the flow-LM prefill (6 layers at d_model 1024, 16 heads of 64,
+  over 16 positions) and Mimi's SEANet decoder (upsampling ratios [6,5,4]), while the same
+  transformer at 1 position and a small stateless function are correct.
 - What settles placement over arithmetic: under `.cpu` the first four samples of a 1920-sample
   frame are **bit-identical** to `.gpu` and `.cpuOnly`, and the divergence starts later in the
-  same frame. Precision loss does not leave a bit-identical prefix.
+  same frame. Precision loss does not leave a bit-identical prefix. That frame is the SEANet
+  decoder's own output frame — one call produces exactly those 1920 PCM samples — rather than an
+  arbitrary window.
 
 **Blast radius varies enormously.** On pocket-tts's fp32 assets it reaches cosine mean 0.501,
 min 0.222, max abs 2.117, with 27 of 32 end-of-sequence decisions flipped — anti-correlated, not
@@ -95,16 +98,20 @@ collapses to a single unit.
 
 ## The other Core AI defects this port found
 
-All verified with minimal repros. Two are filed with Apple (1, 2); the rest are written up.
+All verified with minimal repros, and all five are filed with Apple: FB24322424 (1), FB24322437 (2),
+FB24322585 (3), FB24322596 (4), FB24322605 (5).
 
 1. **`ConvTranspose1d` is numerically wrong on the `cpu_only` delegate** at stride ≥ 8 and
    kernel ≥ 16 — the same asset is correct on gpu. Mimi's k=32/s=16/groups=512 upsample hit it at
    cos −0.01. Escape: at T=1 with `groups == channels` the op degenerates to a per-channel outer
-   product, and re-authoring it that way is bit-exact on `cpu_only`. *(Filed.)*
+   product, `out[c,:] = x[c,0] * W[c,0,:]`, and re-authoring it that way is bit-exact on
+   `cpu_only`. **T=1 is what makes that escape available, not a condition of the defect** —
+   T=1, T=4 and T=64 all fail, so a reader who takes T=1 for the trigger will wrongly conclude
+   they are safe at larger T.
 2. **The Python `coreai.runtime` bindings leak one IOSurface per call** — with this pipeline's
    state sizes the process dies at ~2,250 calls, climbing 1.9 MB per call to ~3 GB. Run Python
    harnesses in subprocess workers on a call budget. The Swift `CoreAI` framework does not leak:
-   4,773 calls flat at 300 MB. *(Filed.)*
+   4,773 calls flat at 300 MB.
 3. **coreai-torch lowers ConvTranspose `output_padding` by padding the input**, silently producing
    the wrong output length. A converter defect, distinct from the *symbolic* output length
    [`kokoro-tts.md`](kokoro-tts.md) records for the same op.

--- a/models/pocket-tts/README.md
+++ b/models/pocket-tts/README.md
@@ -58,8 +58,8 @@ upstream, seed-matched); on matched rows longer than 6 words the two are 2.22 % 
 (+0.09 pp per decile against 4.7 pp decile spread), all 96 stitch points below the
 in-audio p99.9 step, no crossfade needed.
 
-Device transfer (iPhone 17 Pro Max, A19 Pro, iOS 27.0, Release): under `cpuOnly` all 8
-per-graph probe dumps are bit-identical to the M4 Pro, including post-run KV and Mimi
+Device transfer (iPhone 17 Pro Max, A19 Pro, iOS 27 beta 5 (24A5408d), Release): under
+`cpuOnly` all 8 per-graph probe dumps are bit-identical to the M4 Pro, including post-run KV and Mimi
 state. On gpu the oracle-prompt wav scores cos 1.000000, max abs 4.3e-5, and the ASR
 numbers reproduce the Mac's exactly (0.00 % and 1.38 %). fp16 does not transfer bit-wise
 across chips (A19 Pro against M4 Pro), and gpu fp32 is not bit-transferable across GPU
@@ -68,7 +68,8 @@ correctness is carried by the oracle-prompt cosine, the framing, and the ASR gat
 
 ## Speed
 
-Mac, M4 Pro, 148-word paragraph, voice alba, load excluded, 1 warmup + 3 timed, medians.
+Mac, M4 Pro, macOS 27 Golden Gate beta 5 (26A5406e), 148-word paragraph, voice alba, load
+excluded, 1 warmup + 3 timed, medians.
 The quiet-machine ladder (M1-era assets, fresh subprocess per run):
 
 | stack | RTF | x realtime |
@@ -84,14 +85,26 @@ remaining wall is the flow-LM step graph itself. Honest framing: faster than ups
 PyTorch on the same Mac, behind Metal-native MLX; the case for this port is the phone
 and the Swift host, not Mac headline speed.
 
-Device, iPhone 17 Pro Max (A19 Pro), iOS 27.0, Release build, JIT `.aimodel`, charging,
-thermal nominal before and after every run, same paragraph and protocol:
+Device, iPhone 17 Pro Max (A19 Pro), iOS 27 beta 5 (24A5408d), Release build, JIT
+`.aimodel`, charging, thermal nominal before and after every run, same paragraph and protocol:
 
 | config | RTF median | x realtime | peak RSS | load |
 |---|---:|---:|---:|---:|
 | fp32 gpu | 0.1646 | 6.1x | 202 MB | 0.7 s |
 | fp16 gpu | 0.1281 | 7.8x | 169 MB | 0.4 s |
 | fp32 cpuOnly (spot check) | 0.5324 | 1.9x | 225 MB | 0.02 s |
+
+Those two beta 5 builds are load-bearing, and more than they should be. On an iPhone 17
+Pro running an earlier iOS 27 build (24A5380h), these bundles do not load at all: SIGSEGV
+inside `MPSGraph GPU::AssignVariableOpHandler` during `GPURegionRuntime::initializeOps()`
+under `.gpu`, `failedToSpecialize` under `.cpuOnly`, fp32 and fp16 alike, and the same
+after AOT-compiling them for h18p locally. Re-exporting this recipe with a different
+toolchain reproduces the other half of it: the two graphs that carry in-graph state
+(`flowlm`, `mimi`) then fail to load even on a Mac with `AIModelError error 1`, while the
+stateless `flow_decoder` exports and gates clean on both cpu and gpu. So loadability of a
+stateful bundle appears coupled to the OS and SDK build pair rather than to anything in
+the recipe, and the builds above are a floor rather than a note on provenance. Both halves
+of that were reported by @john-rocky.
 
 gpu is 3.2x faster than cpuOnly on device, measured rather than assumed from the Mac.
 Warmup (first-call specialization) is about 0.3 s on device against about 4.5 s on the
@@ -110,15 +123,15 @@ Core ML and Core AI are the only phone routes for this model today.
 
 ## The port in five Core AI bugs
 
-All five are verified with minimal repros. Two are filed with Apple — the ConvTranspose
-`cpu_only` defect (1) and the Python bindings' IOSurface leak (2); the other three are written
-up and not yet submitted. Repros are available on request.
+All five are verified with minimal repros, and all five are filed with Apple: FB24322424 (1),
+FB24322437 (2), FB24322585 (3), FB24322596 (4), FB24322605 (5). Repros are available on request.
 
 1. **ConvTranspose1d is numerically wrong on the `cpu_only` delegate** at stride >= 8
    and kernel >= 16 (the same asset is correct on gpu). Mimi's k=32/s=16/groups=512
    upsample hit it at cos -0.01. Workaround: at T=1 with groups == channels the op
-   degenerates to a per-channel outer product, and re-authoring it that way takes
-   `cpu_only` to bit-exact.
+   degenerates to a per-channel outer product (`out[c,:] = x[c,0] * W[c,0,:]`), and
+   re-authoring it that way takes `cpu_only` to bit-exact. T=1 is what makes that escape
+   available, not a condition of the defect: T=1, T=4 and T=64 all fail.
 2. **The Python `coreai.runtime` bindings leak one IOSurface per call.** With this
    pipeline's state sizes the process dies at about 2,250 calls, climbing 1.9 MB per
    call to about 3 GB. Every Python harness runs generation in subprocess workers on a


### PR DESCRIPTION
Two files, both following from the PR #12 thread.

## `knowledge/pocket-tts-port.md`

The three things you asked me to check, plus one you could not have known.

**All five defects are filed with Apple, not two.** The note inherited that from the card, and the card was stale. Numbers rather than a count, in list order: FB24322424 (1), FB24322437 (2), FB24322585 (3), FB24322596 (4), FB24322605 (5).

**The two failing graphs are named.** The flow-LM prefill is 6 layers at d_model 1024 with 16 heads of 64, and the convolutional one is Mimi's SEANet decoder at upsampling ratios [6,5,4]. Naming the second is what makes the section internally consistent: one call of that decoder produces exactly the 1920 PCM samples whose first four stay bit-identical, so the frame in the placement argument is the decoder's own output frame rather than a window I picked.

**The ConvTranspose escape needed a guard.** You have it right, and the form is `out[c,:] = x[c,0] * W[c,0,:]`. But T=1 is what makes the escape available, not a condition of the defect. T=1, T=4 and T=64 all fail, and a reader who reaches for that paragraph will otherwise conclude they are safe at larger T, which is the one wrong thing they could take from it.

I did not touch the Kokoro section. Rounding scale with two orders of magnitude of headroom is what your numbers say, and a second sighting that reports itself as survivable is worth more than one that overstates.

## `models/pocket-tts/README.md`

Same filing correction and same T=1 guard, since the card carried the same sentence.

Then the line you asked for, which grew into a paragraph because I think your finding deserves more than provenance. The builds are now on the runs themselves: iOS 27 beta 5 (24A5408d) on device, macOS 27 Golden Gate beta 5 (26A5406e) on the Mac. Underneath the numbers is your report of both halves: 24A5380h not loading these bundles at all, and your own toolchain producing `flowlm` and `mimi` bundles that fail on a Mac while the stateless `flow_decoder` stays clean. Whatever that is, it tracks in-graph state across build pairs rather than anything in the recipe, and someone choosing a build to test on needs to know it before they conclude the port is broken.

Reword any of it. Both files are as much yours as mine at this point.