### PR TITLE
ANE submissions: point at where the finding was actually published

### DIFF
--- a/knowledge/compute-units-and-authoring.md
+++ b/knowledge/compute-units-and-authoring.md
@@ -84,7 +84,7 @@ against 183.9 ms ANE-authored on ane, a 3.7× gap against 1.8× on the phone. Ha
 
 Instruments `ane-hw-intervals` traces of the same encoder, one phone, same fp16 weights, same
 authoring — Core AI against a Core ML conversion of the same network, exported and measured by
-[Rahul Rachuri](https://github.com/RahulRachuri) ([traces](https://gist.github.com/RahulRachuri/6761fdb6eb940bd25e4b55926925fbb4)):
+[Rahul Rachuri](https://github.com/RahulRachuri), who published the finding himself ([write-up](https://rachuri.me/blog/parakeet-apple-silicon/), [traces](https://gist.github.com/RahulRachuri/6761fdb6eb940bd25e4b55926925fbb4)):
 
 | per encoder pass | Core AI, ANE-authored | Core ML, converted |
 |---|---:|---:|


### PR DESCRIPTION
One link. The 25-vs-1 submission measurement is Rahul Rachuri's, and he has now published it himself:

> Core AI submits our 24-layer encoder to the ANE as 25 separate jobs with ~2 ms of round-trip overhead between each, so roughly a third of the ANE's wall time is dispatch rather than compute, while CoreML fuses the identical graph into one job.

The section already credited him and linked the traces; it now links the write-up too, so the same numbers have one source of record instead of three copies.