### PR TITLE
Device harness: the four traps that cost this session's shoot its afternoon

### DIFF
--- a/knowledge/ship-playbook.md
+++ b/knowledge/ship-playbook.md
@@ -84,5 +84,22 @@ one). Commit (explicit paths). Draft the X post with the measured RTF — **post
 - **`devicectl` facts:** `install` preserves the app data container (sideloaded files survive a
   reinstall); env vars need the `-e '{"K":"V"}'` JSON flag; copy individual files (bulk can
   false-succeed). `GraphModel`/`AIModel(contentsOf:)` load `.aimodel` *or* `.aimodelc`.
+- **A crash with no log is usually the log's fault.** `print` under `devicectl … --console` goes to a
+  block-buffered stdout, and the buffer dies with the process — so a SIGSEGV inside a load call reads
+  as a crash with zero output. Write diagnostics with `fputs(…, stderr)` + `fflush`: one line before
+  the suspect call localizes it. Piping `--console` through `tail` hides everything until EOF too;
+  use `head` or redirect to a file.
+- **`devicectl` must come from the Xcode whose SDK matches the device OS.** After an iOS update the
+  stable Xcode's `devicectl` hung with no output and no error while the phone was healthy;
+  `DEVELOPER_DIR=/Applications/Xcode-<beta>.app/…/Developer` fixed it immediately. `list devices`
+  also returns **simulators with the same marketing name** — select on
+  `connectionProperties.transportType` (`wired`/`localNetwork`), never on the model string.
+- **There is no simulator path for a Core AI app.** The simulator SDK ships no `CoreAI` framework, so
+  any simulator destination fails at `Unable to resolve module dependency: 'CoreAI'`. To see a screen
+  without a device, render the SwiftUI view offscreen with `ImageRenderer` at the phone's point size.
+- **A single on-device run measures specialization, not throughput.** The first call after load
+  specializes the graphs: Parakeet v2 on an iPhone 17 Pro measured **7.2× realtime on the first pass
+  and 67.8× on the next**, same clip, same process. Anything that shows one number — a demo app as
+  much as a bench — must discard a warmup pass or it reports a figure no workload ever sees.
 - **`Bundle.module` / cross-file symbols show as SourceKit errors in-editor** until a real build
   regenerates the resource accessor — `swift build` is the source of truth, not the squiggles.

--- a/models/parakeet-v2/README.md
+++ b/models/parakeet-v2/README.md
@@ -79,6 +79,13 @@ from about 0.50 s to about 0.78 s as it did. Of the compute, the encoder is 73.7
 the TDT loop 11.40 s, and 90 % of that loop is predictor dispatch at 500 µs across 20528
 calls — the decode side is dispatch-bound, not compute-bound.
 
+Through CoreAIKit rather than the author's host: `KitParakeetModel` loads all three graphs on
+one compute unit and runs the TDT loop synchronously, one `joint` call per encoder frame. On an
+iPhone 17 Pro with everything on `gpu`, one full 28.75 s window measures 0.42 s — 68× realtime,
+warmup discarded, 256 MB peak. That is the same dispatch-bound decode the table above describes,
+without the two levers it uses (predictor and joint on `cpu`, stream depth 2), so read it as a
+floor for the kit path rather than a comparison with the numbers above.
+
 ## Bundles
 
 [`rahulrachuri/parakeet-tdt-0.6b-v2-coreai`](https://huggingface.co/rahulrachuri/parakeet-tdt-0.6b-v2-coreai),


### PR DESCRIPTION
Four device-side traps the ship playbook did not have, plus one scoped measurement on the Parakeet v2 card.

**ship-playbook.md** — none of these are about a model:

- A crash with no console output is usually stdout buffering. `print` under `devicectl --console` is block-buffered and the buffer dies with the process, so a SIGSEGV inside a load call reads as a crash with zero output. `fputs(…, stderr)` + `fflush` before the suspect call localizes it.
- `devicectl` from an Xcode whose SDK predates the device OS hangs with no output and no error. Its `list devices` also returns simulators sharing the phone's marketing name — select on `transportType`.
- There is no simulator path for a Core AI app: the simulator SDK has no `CoreAI` framework. Render the view offscreen with `ImageRenderer` instead.
- A single on-device run measures first-call specialization. Parakeet v2 read 7.2× realtime on the first pass and 67.8× on the next, same clip, same process.

**models/parakeet-v2/README.md** — what the kit's own path measures on a phone (68× over one 28.75 s window, iPhone 17 Pro, all three graphs on `gpu`), written as a floor for that path rather than a comparison: `KitParakeetModel` runs the TDT loop synchronously on one compute unit and so has neither of the levers the card's table uses.