### PR TITLE
Recheck the ConvTranspose defect claims against coreai-torch 0.4.2

### DIFF
--- a/conversion/export_kokoro.py
+++ b/conversion/export_kokoro.py
@@ -53,10 +53,12 @@ Why three bundles + masking + host source (every workaround is load-bearing):
   * weight_norm MUST be folded (`torch.nn.utils.remove_weight_norm`): kokoro uses
     the old hook-based weight_norm, so `module.weight` stays at its random init
     value until a forward fires -- and the manual conv stand-ins read it directly.
-  * ConvTranspose1d output_padding makes the coreai output length symbolic, and
-    coreai's conv_transpose1d returns all zeros for the iSTFT -> both replaced by a
-    bit-exact zero-insertion + conv1d. input_ids are int32; atan2 -> 2*atan; the
-    `%1` in SineGen is a no-op for speech (f0/sr<1) and dropped.
+  * ConvTranspose1d is replaced by a bit-exact zero-insertion + conv1d. The original
+    reasons (a symbolic output length from output_padding; conv_transpose1d returning
+    all zeros for the iSTFT) no longer reproduce as of coreai-torch 0.4.1/0.4.2, but
+    the iSTFT rewrite still has to stay -- see its docstring.
+  * input_ids are int32; atan2 -> 2*atan; the `%1` in SineGen is a no-op for speech
+    (f0/sr<1) and dropped.
 
 Run on the Core AI CPU compute unit (the unrolled LSTM is fast there, ~8 ms;
 on the GPU it is dispatch-bound). Numerics gate = magspec-corr vs the torch
@@ -129,8 +131,13 @@ def _run_lstm(lstm, x, real_mask):
 # export-friendly, numerically-faithful monkeypatches
 # ===========================================================================
 def _manual_depthwise_ctranspose(x, ct):
-    """Depthwise ConvTranspose1d (k3 s2 p1 op1) as zero-insertion + conv1d
-    (output_padding makes the coreai output length symbolic)."""
+    """Depthwise ConvTranspose1d (k3 s2 p1 op1) as zero-insertion + conv1d.
+
+    Written for a symbolic coreai output length under output_padding, which no longer
+    reproduces: this config converts and runs clean on 0.4.1 and 0.4.2, gpu and
+    cpu_only, to 2.4e-07 through a downstream concat. Kept because it is bit-exact and
+    verified in the shipped graph; dropping it needs a full kokoro re-export first.
+    """
     C = ct.in_channels
     B, _, L = x.shape
     up = x.new_zeros(B, C, 2 * L)
@@ -140,8 +147,15 @@ def _manual_depthwise_ctranspose(x, ct):
 
 
 def _manual_convT_general(x, weight, bias, stride, padding=0):
-    """General conv_transpose1d as zero-insertion + conv1d (coreai's
-    conv_transpose1d returns all zeros for the iSTFT)."""
+    """General conv_transpose1d as zero-insertion + conv1d.
+
+    DO NOT remove this. The original symptom (all zeros) is gone, so the old comment
+    invited exactly that. The rewrite is still required: at the iSTFT shape (11 -> 1,
+    k=20, s=5) coreai's conv_transpose1d is correct on gpu (4.8e-07) and wrong on
+    cpu_only (max|d| 4.86) on both 0.4.1 and 0.4.2, and kokoro ships
+    GraphModel(computeUnits: .cpu). That is FB24322424, which is still open -- any
+    ConvTranspose with kernel >= 8 is exposed on cpu_only.
+    """
     B, Cin, L = x.shape
     K = weight.shape[-1]
     up = x.new_zeros(B, Cin, stride * L - (stride - 1))

--- a/knowledge/kokoro-tts.md
+++ b/knowledge/kokoro-tts.md
@@ -77,10 +77,16 @@ torch's and shifts the mask. 0.13 → 0.98.
   classic on-device-TTS trap; existing CoreML ports also compute this **one windowed FFT on the
   host**. So `compute_har` (f0_upsamp + SineGen + STFT) runs host-side (torch/Swift, fp32-stable);
   engine output then matches torch (magspec 0.9994).
-- **`ConvTranspose1d` with `output_padding`** → a *symbolic* output length that poisons later concats
-  ("shapes don't match"). **`conv_transpose1d`** (the iSTFT, stride 5, 11→1) → returns **all zeros**
-  on Core AI. Both fixed by **zero-insertion + `conv1d`** (insert stride-1 zeros + plain conv with the
-  flipped kernel) → bit-exact and correct on the engine.
+- **`ConvTranspose1d`** → both uses are rewritten as **zero-insertion + `conv1d`** (insert stride-1
+  zeros + plain conv with the flipped kernel) → bit-exact and correct on the engine. **The two
+  symptoms this was written for are gone; the rewrite still has to stay.** As of coreai-torch
+  0.4.1/0.4.2 the `output_padding` case (k3 s2 p1 op1) converts and runs clean on gpu and cpu_only
+  to 2.4e-07 through a downstream concat, and the iSTFT case (stride 5, 11→1, k=20) returns real
+  audio rather than zeros. The iSTFT case still comes out wrong on **cpu_only**
+  (max|Δ| 4.86 against torch, correct on gpu at 4.8e-07): this port ships
+  `GraphModel(computeUnits: .cpu)`, so `_manual_convT_general` is holding that. The cause is
+  **FB24322424**, still open: ConvTranspose on `cpu_only` is wrong at kernel ≥ 8 at any stride, or
+  stride ≥ 16 at any kernel.
 - `aten.atan2` unsupported → half-angle `2·atan(y / (√(x²+y²) + x))`. `aten.remainder` (`%1`) is
   identity in the audio range → removed. `input_ids` must be **int32**.
 

--- a/knowledge/pocket-tts-port.md
+++ b/knowledge/pocket-tts-port.md
@@ -99,10 +99,18 @@ collapses to a single unit.
 ## The other Core AI defects this port found
 
 All verified with minimal repros, and all five are filed with Apple: FB24322424 (1), FB24322437 (2),
-FB24322585 (3), FB24322596 (4), FB24322605 (5).
+FB24322585 (3), FB24322596 (4), FB24322605 (5). **FB24322585 (3) is fixed in coreai-torch 0.4.2**;
+the rest still reproduce there. Re-verification detail is under each item.
 
-1. **`ConvTranspose1d` is numerically wrong on the `cpu_only` delegate** at stride ≥ 8 and
-   kernel ≥ 16 — the same asset is correct on gpu. Mimi's k=32/s=16/groups=512 upsample hit it at
+1. **`ConvTranspose1d` is numerically wrong on the `cpu_only` delegate** — the same asset is
+   correct on gpu. **The trigger is wider than this note first claimed.** It was written up as
+   stride ≥ 8 *and* kernel ≥ 16; a kernel × stride grid on 0.4.2 (plain `ConvTranspose1d(4,4,k,
+   stride=s)`, `[1,4,8]` fp32, `cpu_only` vs torch) puts it at **kernel ≥ 8 at any stride, stride 1
+   included, or stride ≥ 16 at any kernel** — a disjunction. k=8/s=1 fails, k=2/s=16 fails,
+   k=4/s=8 is clean. Errors are order 1.0 on values of order 1, so nothing here is a rounding
+   margin. A nonzero `output_padding` escapes it (k=16/s=8 is wrong at op=0 and clean at op=1..7),
+   which suggests the op takes a different lowering path once `output_padding` is set.
+   Mimi's k=32/s=16/groups=512 upsample hit it at
    cos −0.01. Escape: at T=1 with `groups == channels` the op degenerates to a per-channel outer
    product, `out[c,:] = x[c,0] * W[c,0,:]`, and re-authoring it that way is bit-exact on
    `cpu_only`. **T=1 is what makes that escape available, not a condition of the defect** —
@@ -112,9 +120,13 @@ FB24322585 (3), FB24322596 (4), FB24322605 (5).
    state sizes the process dies at ~2,250 calls, climbing 1.9 MB per call to ~3 GB. Run Python
    harnesses in subprocess workers on a call budget. The Swift `CoreAI` framework does not leak:
    4,773 calls flat at 300 MB.
-3. **coreai-torch lowers ConvTranspose `output_padding` by padding the input**, silently producing
-   the wrong output length. A converter defect, distinct from the *symbolic* output length
-   [`kokoro-tts.md`](kokoro-tts.md) records for the same op.
+3. **coreai-torch lowered ConvTranspose `output_padding` by padding the input**, silently producing
+   the wrong output length. A converter defect. **Fixed in coreai-torch 0.4.2.** A 66-case sweep
+   over (kernel, padding) ∈ {(4,1), (16,0), (3,1)} × stride ∈ {2,3,4,5,8} × every legal
+   `output_padding` gives 41 wrong lengths on 0.4.1 and 0 on 0.4.2, with values matching torch to
+   1.2e-07. The overshoot grew with stride: k=4/s=8/p=1/op=7 returned 107 against torch's 65.
+   `output_padding` 0 was always correct and 1 was correct at `padding=1`, which is why this port
+   never saw it — the streaming rewrite sets no `output_padding` at all.
 4. **fp32 graphs with in-graph state abort under the default `SpecializationOptions`** — SIGABRT
    in `ANERegionFormationPass` instead of falling back. State an explicit `gpu` or `cpuOnly`
    preference on every load; see the placement section above.

--- a/models/kokoro-82m/README.md
+++ b/models/kokoro-82m/README.md
@@ -181,8 +181,12 @@ workaround below is load-bearing.
 4. **The hn-nsf source goes on the host.** Its STFT phase (atan2) flips 2π at the
    F0→0 pad boundary under fp32 on the engine; computing that one windowed FFT on the
    host (`compute_har`) makes the engine match torch.
-5. **Two coreai op traps.** `ConvTranspose1d` with `output_padding` gives a *symbolic*
-   output length that poisons later concats, and `conv_transpose1d` returns **all
-   zeros** for the iSTFT — both replaced by a bit-exact **zero-insertion + conv1d**.
+5. **One coreai op trap, and a rewrite that outlived its original reason.** Both
+   `ConvTranspose1d` uses are replaced by a bit-exact **zero-insertion + conv1d**. The
+   symptoms this was written for (a symbolic output length under `output_padding`;
+   `conv_transpose1d` returning **all zeros** for the iSTFT) no longer reproduce on
+   coreai-torch 0.4.1/0.4.2. The iSTFT rewrite still has to stay: at that shape
+   `conv_transpose1d` is wrong on **cpu_only** (max|Δ| 4.86, correct on gpu), and this
+   port ships `computeUnits: .cpu`. That is **FB24322424**, still open. Alongside these,
    `input_ids` must be int32; `atan2(y,x)` → `2·atan(y/(|z|+x))`; SineGen's `%1` is a
    no-op for speech (f0/sr<1) and dropped.

--- a/models/pocket-tts/README.md
+++ b/models/pocket-tts/README.md
@@ -125,9 +125,14 @@ Core ML and Core AI are the only phone routes for this model today.
 
 All five are verified with minimal repros, and all five are filed with Apple: FB24322424 (1),
 FB24322437 (2), FB24322585 (3), FB24322596 (4), FB24322605 (5). Repros are available on request.
+**FB24322585 (3) is fixed in coreai-torch 0.4.2.** The other four still reproduce there.
 
-1. **ConvTranspose1d is numerically wrong on the `cpu_only` delegate** at stride >= 8
-   and kernel >= 16 (the same asset is correct on gpu). Mimi's k=32/s=16/groups=512
+1. **ConvTranspose1d is numerically wrong on the `cpu_only` delegate** (the same asset
+   is correct on gpu). **The trigger is wider than this card first claimed.** It was
+   written up as stride >= 8 *and* kernel >= 16; a kernel x stride grid on 0.4.2 puts it
+   at kernel >= 8 at any stride, stride 1 included, or stride >= 16 at any kernel. So
+   k=8/s=1 fails and k=2/s=16 fails, while k=4/s=8 is clean. A nonzero `output_padding`
+   escapes it. Mimi's k=32/s=16/groups=512
    upsample hit it at cos -0.01. Workaround: at T=1 with groups == channels the op
    degenerates to a per-channel outer product (`out[c,:] = x[c,0] * W[c,0,:]`), and
    re-authoring it that way takes `cpu_only` to bit-exact. T=1 is what makes that escape
@@ -137,10 +142,10 @@ FB24322437 (2), FB24322585 (3), FB24322596 (4), FB24322605 (5). Repros are avail
    call to about 3 GB. Every Python harness runs generation in subprocess workers on a
    1,500-call budget. The Swift `CoreAI` framework does not leak: one process ran 4,773
    calls flat at 300 MB.
-3. **coreai-torch lowers ConvTranspose `output_padding` by padding the input**, which
-   silently produces the wrong output length. This is a converter defect and goes to the
-   apple/coreai-torch tracker as well as Feedback Assistant. The streaming rewrite here
-   never uses `output_padding`, so the port is unaffected; the repro is in the report.
+3. **coreai-torch lowered ConvTranspose `output_padding` by padding the input**, which
+   silently produced the wrong output length. **Fixed in coreai-torch 0.4.2**: a 66-case
+   sweep gives 41 wrong lengths on 0.4.1 and 0 on 0.4.2. The streaming rewrite here never
+   uses `output_padding`, so the port was unaffected either way.
 4. **fp32 graphs with in-graph state abort the process under the default
    `SpecializationOptions`** (SIGABRT in ANERegionFormationPass) instead of falling back.
    Since both main graphs carry in-graph state, every load states an explicit `gpu` or


### PR DESCRIPTION
Three ConvTranspose claims in the zoo rechecked against [coreai-torch 0.4.2](https://github.com/apple/coreai-torch/releases). Docs and comments only, no code paths changed.

### 1. `output_padding` lowering is fixed (FB24322585)

coreai-torch lowered ConvTranspose `output_padding` by padding the input, returning a longer tensor than PyTorch with no error. Sweep over (kernel, padding) ∈ {(4,1), (16,0), (3,1)} × stride ∈ {2,3,4,5,8} × every legal `output_padding`:

| | 0.4.1 | 0.4.2 |
|---|---|---|
| wrong output length | 41 / 66 | **0 / 66** |

Lengths match torch exactly on 0.4.2, values to 1.2e-07. Overshoot grew with stride: k=4/s=8/p=1/op=7 returned 107 against torch's 65.

No workaround becomes removable. kokoro is the only model setting `output_padding` non-zero, and its k3/s2/p1/op1 was already correct on 0.4.1 (`output_padding` 0 always correct, 1 correct at `padding=1`). Every other ConvTranspose user leaves it at 0; voxcpm pins it and trims right by hand.

### 2. FB24322424's trigger is wider than filed

Still open on 0.4.2. Filed as stride ≥ 8 **and** kernel ≥ 16. Kernel × stride grid on `cpu_only`, plain `ConvTranspose1d(4,4,k,stride=s)` over `[1,4,8]` fp32, gpu correct throughout at ~1e-07:

```
  k\s      1     2     4     8    16
    2     ok    ok    ok    ok   BAD
    3     ok    ok    ok    ok   BAD
    4     ok    ok    ok    ok   BAD
    5     ok    ok    ok    ok   BAD
    6     ok    ok    ok    ok   BAD
    8    BAD   BAD   BAD   BAD   BAD
   12    BAD   BAD   BAD   BAD   BAD
   16    BAD   BAD   BAD   BAD   BAD
   32    BAD   BAD   BAD   BAD   BAD
```

The condition is a disjunction: kernel ≥ 8 at any stride including stride 1, or stride ≥ 16 at any kernel. k=8/s=1 fails, k=2/s=16 fails, k=4/s=8 is clean. Errors are order 1.0 on values of order 1. The old wording reads a kernel-8 or stride-1 layer as safe. Follow-up with this grid filed with Apple.

### 3. Both kokoro ConvTranspose trap descriptions are stale

Neither documented symptom reproduces on 0.4.1 or 0.4.2:

| documented | measured |
|---|---|
| `output_padding` → symbolic length that "poisons later concats" | clean on gpu and cpu_only, 2.4e-07, through a downstream concat |
| iSTFT `conv_transpose1d` (11→1, k20, s5) → all zeros | real audio. Correct on gpu (4.8e-07), wrong on cpu_only (max\|Δ\| 4.86) |

`_manual_convT_general` still has to stay, for the second reason rather than the one its docstring gives: kokoro ships `GraphModel(computeUnits: .cpu)` and that shape sits inside FB24322424's range. The docstring now says that, since the symptom it named is gone and would otherwise read as licence to delete a live rewrite.

`_manual_depthwise_ctranspose` is droppable in isolation. Left in place, with the isolated-module caveat in its docstring — confirming it needs a full kokoro re-export.

### Verified on

coreai-torch 0.4.2 (PyPI, `--no-deps --target`, zoo venv left at 0.4.1) / coreai-core 1.0.0b2 / torch 2.11.0, macOS 27.0 (Darwin 27.0.0), Apple silicon. Repro scripts on request.

### Open question

`stable-audio-open-small`'s decoder has ConvTranspose kernels of 8, 8, 16, 16, and no compute unit stated in its `recipe.toml` or README. On `cpu_only` it sits inside FB24322424's range. vibevoice and voxcpm both AOT-compile with `--preferred-compute gpu`, so they are clear. One for whoever owns that port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)