### PR TITLE
Conversion clinic: issue template and README entry points

### DIFF
--- a/.github/ISSUE_TEMPLATE/conversion-clinic.yml
+++ b/.github/ISSUE_TEMPLATE/conversion-clinic.yml
@@ -1,0 +1,43 @@
+name: Conversion clinic
+description: A model or a Core ML project that will not convert to Core AI. An error message is enough to start.
+title: "[clinic] "
+labels: ["clinic"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Paste what you have. Only the first field is required. We ask for anything missing.
+        On the clinic day after the iOS 27 / macOS 27 release (announced in the pinned issue) every ticket gets a same-day answer: a fix, or the reason it cannot be done yet. Other days: best effort.
+  - type: textarea
+    id: tried
+    attributes:
+      label: What you tried, and what happened
+      description: The command or code, and the error text or the wrong output. Verbatim is best. If you already searched the error string, say where it led.
+    validations:
+      required: true
+  - type: input
+    id: model
+    attributes:
+      label: Model or project
+      description: Hugging Face URL or name, or a link to the Core ML project
+      placeholder: "https://huggingface.co/Qwen/Qwen3-0.6B"
+    validations:
+      required: false
+  - type: input
+    id: env
+    attributes:
+      label: Environment
+      description: macOS / iOS build, Xcode, coreai-torch version, device
+      placeholder: "macOS 27.0 (26A353), Xcode 27, coreai-torch 0.4.2, iPhone 17 Pro"
+    validations:
+      required: false
+  - type: dropdown
+    id: writeup
+    attributes:
+      label: May we publish the fix in the knowledge base?
+      options:
+        - "Yes"
+        - "Yes, without naming me"
+        - "No"
+    validations:
+      required: false

--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ kernel — the stock MPSGraph SDPA crashes on the ≥16-head × 512 Q (a GPU scr
 - **Make it fast** → [`knowledge/custom-metal-kernels.md`](knowledge/custom-metal-kernels.md) · [`knowledge/performance-ceiling.md`](knowledge/performance-ceiling.md)
 - **Known beta issue** (in-graph KV-write crash; workarounds + the input-mask escape) → [`knowledge/coreai-beta-mpsgraph-kvwrite-bug.md`](knowledge/coreai-beta-mpsgraph-kvwrite-bug.md) — FB23024751 / [apple/coreai-models#5](https://github.com/apple/coreai-models/issues/5)
 - **Hit an error string** (`LLVM ERROR: …`, `failed assertion …`, `failedToSpecialize`, `NSPOSIXErrorDomain Code=2`, …) → [`knowledge/coreai-error-index.md`](knowledge/coreai-error-index.md) — every exact string this project has observed, verbatim as a heading, with the verified cause, the fix, and the log or Apple issue behind it
+- **Still stuck** → [conversion clinic](https://github.com/john-rocky/coreai-model-zoo/issues/new?template=conversion-clinic.yml) — paste the error, get an answer
 
 ## Repository layout
 
@@ -409,6 +410,7 @@ for you if you don't have the device.
 - **Port a model** — [`PORTING.md`](PORTING.md) walks the whole path (oracle → export → gates →
   publish); PRs welcome.
 - **Conversion requests** — a model you'd like to see here? [Open an issue](https://github.com/john-rocky/coreai-model-zoo/issues/new) with the Hugging Face link and what you'd use it for.
+- **Stuck converting?** Open a [conversion clinic](https://github.com/john-rocky/coreai-model-zoo/issues/new?template=conversion-clinic.yml) issue. The error text alone is enough to start; we ask for the rest. On the clinic day after the OS 27 release every ticket gets a same-day answer — a fix, or the reason it cannot be done yet. Search your error string first in [`knowledge/coreai-error-index.md`](knowledge/coreai-error-index.md); if it is there, so is the fix.
 - **No code needed** — run the Bench tab in [CoreAIChat (TestFlight)](https://testflight.apple.com/join/bK4P7xby) and submit the result: your device becomes a row in [`BENCHMARKS.md`](BENCHMARKS.md).
 
 ## Recovery note — the coreai-torch 0.4.0 incident


### PR DESCRIPTION
Adds the intake for the conversion clinic held the day after the iOS 27 / macOS 27 release.

- `.github/ISSUE_TEMPLATE/conversion-clinic.yml` — one required field (what you tried, what happened); model, environment and publish-consent are optional. Label `clinic`.
- `README.md` — a "Stuck converting?" line under Contributing and a "Still stuck" line under Start here, both pointing at the template and at `knowledge/coreai-error-index.md` first.

No code changes. Catalog and llms.txt checks pass (pre-commit).