### PR TITLE
recovery: the 0.4.0 strip drivers, re-verified on 26A5416b

### DIFF
--- a/conversion/recovery/README.md
+++ b/conversion/recovery/README.md
@@ -1,0 +1,27 @@
+# recovery — the in-place repair for coreai-torch 0.4.0-era bundles
+
+Background and evidence: [`knowledge/coreai-torch-041-ir-incident.md`](../../knowledge/coreai-torch-041-ir-incident.md).
+A bundle converted with coreai-torch 0.4.0 (no `producer` in `metadata.json`) is refused at
+`AIModel.load` on every OS 27 build measured since beta 2 (`LLVM ERROR: cannot unwrap empty
+odiec_module_t`). Stripping the debug locations repairs it in place; the weights are untouched.
+
+Two steps, two interpreters, because the b2 wheel's bytecode reader cannot parse the old
+locations and the 0.4.0 wheel lacks `strip_debug_info`:
+
+```bash
+# 1. isolated venv: coreai-torch 0.4.0 + coreai-core 1.0.0b1 (once)
+uv venv -p 3.11 ~/code/coreai/_recovery_venvs/strip
+uv pip install --python ~/code/coreai/_recovery_venvs/strip/bin/python "coreai-torch==0.4.0" "coreai-core==1.0.0b1"
+
+# 2. strip in the b1 venv, then re-save with the b2 wheel (stamps producer) and load it
+~/code/coreai/_recovery_venvs/strip/bin/python conversion/recovery/strip_b1.py <in.aimodel> /tmp/stage1.aimodel
+../coreai-models/.venv/bin/python conversion/recovery/resave_b2.py /tmp/stage1.aimodel <out.aimodel>
+```
+
+Re-verified 2026-09-09 on macOS 27 26A5416b (coreai-core 1.0.0b2 for step 2):
+`mlboydaisuke/qwen3.5-0.8B-CoreAI` `gpu-pipelined/qwen3_5_0_8b_decode_int8hu_perchan_sym`
+(1.2 GB, 3253 ops) — strip 2.2 s, re-save 0.9 s, `AIModel.load(cpu_only)` OK where the
+original aborts. `.aimodelc` (compiled) artifacts cannot be stripped; re-export and re-AOT those.
+
+After the repair: `python3 conversion/zoo_smoke.py <repo> --all` records the load with the host
+build, `conversion/zoo_verify.py` runs tier-1, and the upload follows `_publish_tier1_fixes.py`.

--- a/conversion/recovery/resave_b2.py
+++ b/conversion/recovery/resave_b2.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""resave_b2.py — re-load a stripped bundle with the b2 wheel and re-save it (producer stamp), then load it with the runtime (cpu_only).
+
+    coreai-models/.venv/bin/python resave_b2.py <stripped.aimodel> <final.aimodel>
+"""
+import asyncio, json, shutil, sys, time
+from pathlib import Path
+from coreai.authoring import AIModelAsset
+import coreai.runtime as rt
+
+src, dst = Path(sys.argv[1]), Path(sys.argv[2])
+t0 = time.time()
+asset = AIModelAsset.load(src)
+shutil.rmtree(dst, ignore_errors=True)
+asset.program.save_asset(dst, rt.AIModelAssetMetadata())
+print(f"resaved in {time.time()-t0:.1f}s; metadata:", json.loads((dst / "metadata.json").read_text()))
+
+async def main():
+    m = await rt.AIModel.load(dst, rt.SpecializationOptions.cpu_only())
+    print("runtime load OK; functions:", m.function_names)
+asyncio.run(main())
+print(f"done in {time.time()-t0:.1f}s")

--- a/conversion/recovery/strip_b1.py
+++ b/conversion/recovery/strip_b1.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""strip_b1.py — strip debug locations from a coreai-torch 0.4.0-era .aimodel, in the b1 venv.
+
+    _recovery_venvs/strip/bin/python strip_b1.py <in.aimodel> <out.aimodel>
+
+Vendored from coreai-torch 0.4.1 `debugging/debug_info.strip_debug_info` (0.4.0 lacks it).
+Runs in the coreai-torch 0.4.0 + coreai-core 1.0.0b1 venv, whose bytecode reader still parses
+the old fused locations. The output must then be re-saved once with the b2 wheel (resave_b2.py)
+so metadata.json carries `producer: coreai-core 1.0.0b2`.
+"""
+import inspect, sys, time
+from pathlib import Path
+
+import coreai._compiler._mlir_libs._coreaiIR._bindings.mlir as _mlir
+from coreai._compiler.ir import Location
+from coreai.authoring import AIProgram
+import coreai_torch._debug_locations as dl
+
+src, dst = Path(sys.argv[1]), Path(sys.argv[2])
+t0 = time.time()
+program = AIProgram._load_bytecode(src / "main.mlirb")
+print(f"loaded {src.name} in {time.time()-t0:.1f}s")
+
+module_op = program._mlir_module.operation
+context = module_op.context
+
+# 0.4.0 helper signatures (differ from 0.4.1+): _create_unknown_location(context, metadata_attrs=None),
+# _create_operation_id_metadata(op_id, context). No unknown_src argument.
+module_location = dl._create_unknown_location(context)
+dl.set_op_location(module_op, module_location)
+
+count = 0
+for nested_op in dl._get_nested_operations(module_op):
+    op_id = dl.OperationID(type="coreai", value=count)
+    count += 1
+    loc = dl._create_unknown_location(context, [dl._create_operation_id_metadata(op_id, context)])
+    dl.set_op_location(nested_op, loc)
+    for region in nested_op.regions:
+        for block in region:
+            for arg in block.arguments:
+                dl.set_block_arg_location(arg, loc)
+print(f"relocated {count} ops in {time.time()-t0:.1f}s")
+
+import shutil
+shutil.rmtree(dst, ignore_errors=True)
+program.save_asset(dst)
+print(f"saved {dst} in {time.time()-t0:.1f}s")

--- a/knowledge/coreai-torch-041-ir-incident.md
+++ b/knowledge/coreai-torch-041-ir-incident.md
@@ -144,3 +144,10 @@ The working recipe on this machine:
 
 Driver scripts: recovery session scratchpad `strip_b1.py` / `strip_sweep.py`.
 `.aimodelc` (compiled) artifacts cannot be stripped — those need re-export + AOT recompile.
+
+**2026-09-09 — re-verified, drivers checked in.** The two-step recipe above now lives in
+[`conversion/recovery/`](../conversion/recovery/) (`strip_b1.py` for the 0.4.0 + b1 venv, whose helper
+signatures differ from 0.4.1's; `resave_b2.py` for the producer stamp and a `cpu_only` runtime load).
+On macOS 27 26A5416b the `qwen3.5-0.8B` `perchan_sym` bundle that still aborted at load on 2026-09-04
+strips in 2.2 s, re-saves in 0.9 s, and loads. 34 published bundles still carry 0.4.0-era IR
+(`zoo_smoke.py --all --stamp-only`); they are the queue for the GA+2 sweep.


### PR DESCRIPTION
The in-place repair for coreai-torch 0.4.0-era bundles (`strip_debug_info` in a b1 venv, then a re-save with the b2 wheel) lived in a July scratchpad and was lost. This checks the two drivers in under `conversion/recovery/` with a README, and appends the 2026-09-09 re-verification to the incident note: the `qwen3.5-0.8B` `perchan_sym` bundle that aborted at load on 09-04 strips in 2.2 s, re-saves in 0.9 s, and loads (`cpu_only`) on macOS 27 26A5416b.

The 0.4.0 helper signatures differ from 0.4.1's; `strip_b1.py` calls the 0.4.0 forms directly.